### PR TITLE
Xmega Reworks: A Haiku

### DIFF
--- a/CentralComputing/Network.cpp
+++ b/CentralComputing/Network.cpp
@@ -75,7 +75,7 @@ int Network::write_data() {
   size_t size = 0; 
   uint8_t * buffer = (uint8_t *) malloc(capacity);
 
-  for(size_t i = 0; i < Data_ID::NULL_ID; i++){
+  for(size_t i = 0; i < Data_ID::STATE_ID; i++){
     Data_ID id = (Data_ID) i;
     Data d = sensor->get_data(id);  
     size_t delta = 1 + d.raw.size + d.calculated.size; //1 byte for the data_id

--- a/CentralComputing/Network.h
+++ b/CentralComputing/Network.h
@@ -20,6 +20,9 @@ enum Network_Command_ID {
   TRANS_LAUNCH_READY = 3,
   LAUNCH = 4,
   EMERGENCY_BRAKE = 5,
+  ENABLE_MOTOR = 6,
+  DISABLE_MOTOR = 7,
+  SET_MOTOR_SPEED = 8
 };
 
 /**

--- a/CentralComputing/Pod.cpp
+++ b/CentralComputing/Pod.cpp
@@ -67,6 +67,9 @@ void logic_loop(){
       // TODO PID loop
 
     }
+    //TODO: Change to actual value at some point
+    
+    usleep(100);//Need to yield, otherwise this will block other threads
   }
 }
 

--- a/CentralComputing/Pod.cpp
+++ b/CentralComputing/Pod.cpp
@@ -1,6 +1,8 @@
 #include "Pod.h"
+#include "Spi.h"
 
 using namespace std;
+Spi * spi;
 Sensor * sensor;
 Network * network;
 Xmega * xmega;
@@ -51,7 +53,6 @@ void network_loop(){
 
 void logic_loop(){
   while(running){
-    xmega->read();
     sensor->update_buffers();
   }
 }
@@ -70,8 +71,14 @@ int main(){
   // parsing, setup, etc
   signal(SIGINT, int_handler);
   signal(SIGPIPE, pipe_handler);
-  xmega = new Xmega(); 
-  sensor = new Sensor(xmega);
+  spi = NULL;
+  #ifndef SIM
+  // setup SPI 
+  #endif
+ 
+
+  xmega = new Xmega(spi); 
+  sensor = new Sensor(spi);
   network = new Network(sensor);
   const char* host = "127.0.0.1";
   const char* port = "8800";

--- a/CentralComputing/Sensor-sim.cpp
+++ b/CentralComputing/Sensor-sim.cpp
@@ -1,7 +1,7 @@
 #ifdef SIM
 
 #include "Sensor.h"
-Sensor::Sensor(Xmega * xmega) {
+Sensor::Sensor(Spi * s) {
 
 }
 

--- a/CentralComputing/Sensor.cpp
+++ b/CentralComputing/Sensor.cpp
@@ -21,32 +21,37 @@ Sensor::Sensor(Spi * s) : spi(s){
   calculation_map[Data_ID::DISTANCE] = distance_calculation;
   parse_map[Data_ID::DISTANCE] = distance_parse;
 
-    //Temperature
+  //Temperature
   raw_data_map[Data_ID::TEMPERATURE] = *(Arbitrary_Data * ) malloc(sizeof(Temperature_Raw));
   calculation_map[Data_ID::TEMPERATURE] = no_calculation;
   parse_map[Data_ID::TEMPERATURE] = temperature_parse;
 
-    //Ride Height
+  //Ride Height
   raw_data_map[Data_ID::RIDE_HEIGHT] = *(Arbitrary_Data * ) malloc(sizeof(Ride_Height_Raw));
   calculation_map[Data_ID::RIDE_HEIGHT] = no_calculation;
   parse_map[Data_ID::RIDE_HEIGHT] = ride_height_parse;
 
+  //AccelerationX
 	raw_data_map[Data_ID::ACCELERATION_X] = *(Arbitrary_Data *) malloc(sizeof(Acceleration_X_Raw));
 	calculation_map[Data_ID::ACCELERATION_X] = acceleration_x_calculation;
 	parse_map[Data_ID::ACCELERATION_X] = acceleration_x_parse;
 
+  //AccelerationY
 	raw_data_map[Data_ID::ACCELERATION_Y] = *(Arbitrary_Data *) malloc(sizeof(Acceleration_Y_Raw));
 	calculation_map[Data_ID::ACCELERATION_Y] = no_calculation;
 	parse_map[Data_ID::ACCELERATION_Y] = acceleration_y_parse;
 
+  //AccelerationZ
 	raw_data_map[Data_ID::ACCELERATION_Z] = *(Arbitrary_Data *) malloc(sizeof(Acceleration_Z_Raw));
 	calculation_map[Data_ID::ACCELERATION_Z] = no_calculation;
 	parse_map[Data_ID::ACCELERATION_Z] = acceleration_z_parse;
 
+  //Current 
 	raw_data_map[Data_ID::CURRENT] = *(Arbitrary_Data *) malloc(sizeof(Current_Raw));
 	calculation_map[Data_ID::CURRENT] = no_calculation;
 	parse_map[Data_ID::CURRENT] = current_parse;
 
+  //Brake Pressure
 	raw_data_map[Data_ID::BRAKE_PRESSURE] = *(Arbitrary_Data *) malloc(sizeof(Brake_Pressure_Raw));
 	calculation_map[Data_ID::BRAKE_PRESSURE] = no_calculation;
 	parse_map[Data_ID::BRAKE_PRESSURE] = brake_pressure_parse;

--- a/CentralComputing/Sensor.cpp
+++ b/CentralComputing/Sensor.cpp
@@ -83,7 +83,7 @@ void Sensor::update_buffers() {
   for(Data_ID id : ids){
     parse_func_t fun = parse_map[id];
     Arbitrary_Data raw = raw_data_map[id];
-    fun(data_buffer, raw);
+    fun(spi, raw);
   }
 }
 

--- a/CentralComputing/Sensor.cpp
+++ b/CentralComputing/Sensor.cpp
@@ -10,7 +10,7 @@
 #include "Sensor_Aux/Current.h"
 #include "Sensor_Aux/Brake_Pressure.h"
 
-Sensor::Sensor(Xmega * xm) : xmega(xm){
+Sensor::Sensor(Spi * s) : spi(s){
   //setup maps
   raw_data_map = raw_data_map_t();
   calculation_map = calculation_map_t();

--- a/CentralComputing/Sensor.h
+++ b/CentralComputing/Sensor.h
@@ -18,18 +18,18 @@
   A function to convert calculated data
 **/
 enum Data_ID {
-  DISTANCE,
-  VELOCITY,
-  ACCELERATION_X,
-	ACCELERATION_Y,
-	ACCELERATION_Z,
-	VOLTAGE,
-	CURRENT,
-	BRAKE_PRESSURE,
-  TEMPERATURE,
-  RIDE_HEIGHT,
+  DISTANCE = 0,
+  VELOCITY = 1,
+  ACCELERATION_X = 2,
+	ACCELERATION_Y = 3,
+	ACCELERATION_Z = 4,
+	VOLTAGE = 5,
+	CURRENT = 6,
+	BRAKE_PRESSURE = 7,
+  TEMPERATURE = 8,
+  RIDE_HEIGHT = 9,
   //etc etc
-  NULL_ID
+  STATE_ID = 10 // State ID is an invalid ID to request, query the state machine instead
 };
 
 //You can think of Arbitrary Data as a uint8_t * in most circumstances, it just also gives a size

--- a/CentralComputing/Sensor.h
+++ b/CentralComputing/Sensor.h
@@ -8,6 +8,36 @@
 #include <mutex>
 #include <vector>
 
+#define XMEGA1 0
+#define XMEGA2 1
+
+enum Xmega_1_Indices {
+  X_ACCELERATION_INDEX_1 = 0,
+  X_ACCELERATION_INDEX_2 = 1,
+  X_ACCELERATION_INDEX_3 = 2,
+  BRAKE_PRESSURE_INDEX = 3,
+  ENCODER_RPM_INDEX = 4,
+  ENCODER_COUNT_INDEX = 5,
+};
+
+enum Xmega_2_Indices {
+  Y_ACCELERATION_INDEX = 0,
+  Z_ACCELERATION_INDEX = 1,
+  RIDE_HEIGHT_INDEX_1 = 2,
+  RIDE_HEIGHT_INDEX_2 = 3,
+  RIDE_HEIGHT_INDEX_3 = 4,
+  BATTERY_CELL_INDEX_1 = 5,
+  BATTERY_CELL_INDEX_2 = 6,
+  THERMOCOUPLE_INDEX_1 = 7,
+  THERMOCOUPLE_INDEX_2 = 8,
+  THERMOCOUPLE_INDEX_3 = 9,
+  THERMOCOUPLE_INDEX_4 = 10,
+  THERMOCOUPLE_INDEX_5 = 11,
+  CURRENT_INDEX_1 = 12,
+  CURRENT_INDEX_2 = 13,
+  TAPE_COUNT_INDEX = 14
+};
+
 /**Every Data_ID needs:
   1. A Raw_Data_Struct that holds all the relevant raw data for that query
   2. A Calculated_Data_Struct that holds all the calculated data
@@ -36,8 +66,8 @@ enum Data_ID {
 
 // A calculation function takes in a pointer to raw data and converts it to real units
 typedef Arbitrary_Data (*calculation_func_t)(Arbitrary_Data);
-// A parse function takes in a pointer to a buffer, and memcpys the relevant data onto an existing arbitrary data
-typedef void (*parse_func_t)(uint8_t * buffer, Arbitrary_Data data);
+// A parse function takes in a spi reference, and stores necessary data within a Raw_Data_Struct 
+typedef void (*parse_func_t)(Spi * spi, Arbitrary_Data data);
 // Calculation  map takes in a Data_ID and gives a calculation function
 typedef std::map<Data_ID, calculation_func_t> calculation_map_t;
 // Raw data map maps a data_id to some raw_data *
@@ -81,7 +111,6 @@ class Sensor {
 
       Arbitrary_Data get_raw_data(Data_ID id);
       std::vector<Data_ID> ids;
-      uint8_t * data_buffer;
 
     #endif
 

--- a/CentralComputing/Sensor.h
+++ b/CentralComputing/Sensor.h
@@ -52,7 +52,7 @@ class Sensor {
     /**
     * Default constructor
     **/
-    Sensor(Xmega * xmega);
+    Sensor(Spi * s);
 
     /**
     * Updates the buffers with the most recent data
@@ -73,7 +73,7 @@ class Sensor {
     #ifdef SIM
 
     #else
-      Xmega * xmega;
+      Spi * spi;
       calculation_map_t calculation_map;
       raw_data_map_t raw_data_map;
       parse_map_t parse_map;

--- a/CentralComputing/Sensor_Aux/Acceleration_X.cpp
+++ b/CentralComputing/Sensor_Aux/Acceleration_X.cpp
@@ -1,6 +1,7 @@
 #include "Acceleration_X.h"
 
-#define ACCELERATION_X_OFFSET 0 
+
+
 using namespace std;
 
 const double VOLTS_PER_G = 0.330;
@@ -53,9 +54,9 @@ Arbitrary_Data acceleration_x_calculation(Arbitrary_Data raw) {
 	return calculated;
 }
 
-void acceleration_x_parse(uint8_t * buffer, Arbitrary_Data raw) {
+void acceleration_x_parse(Spi* spi, Arbitrary_Data raw) {
 	Acceleration_X_Raw * ax_raw = (Acceleration_X_Raw *)raw.data;
-	ax_raw->one = *(((uint16_t *)buffer) + ACCELERATION_X_OFFSET);
-	ax_raw->two =  *(((uint16_t *)buffer) + ACCELERATION_X_OFFSET+1);
-	ax_raw->three = *(((uint16_t *)buffer) + ACCELERATION_X_OFFSET+2);	
+  ax_raw->one = spi->get_data(XMEGA1, X_ACCELERATION_INDEX_1);
+  ax_raw->two = spi->get_data(XMEGA1, X_ACCELERATION_INDEX_2);
+  ax_raw->three = spi->get_data(XMEGA1, X_ACCELERATION_INDEX_3);
 }

--- a/CentralComputing/Sensor_Aux/Acceleration_X.h
+++ b/CentralComputing/Sensor_Aux/Acceleration_X.h
@@ -1,6 +1,7 @@
 #ifndef ACCELERATION_X_H
 #define ACCELERATION_X_H
 #include "../Data.h"
+#include "../Sensor.h"
 
 struct Acceleration_X_Raw {
 	uint16_t one;
@@ -17,5 +18,5 @@ struct Acceleration_X_Calc {
 };
 
 Arbitrary_Data acceleration_x_calculation(Arbitrary_Data raw);
-void acceleration_x_parse(uint8_t * buffer, Arbitrary_Data raw); 
+void acceleration_x_parse(Spi * spi, Arbitrary_Data raw); 
 #endif

--- a/CentralComputing/Sensor_Aux/Acceleration_Y.cpp
+++ b/CentralComputing/Sensor_Aux/Acceleration_Y.cpp
@@ -4,7 +4,7 @@
 
 using namespace std;
 
-void acceleration_y_parse(uint8_t * buffer, Arbitrary_Data raw) {
+void acceleration_y_parse(Spi * spi, Arbitrary_Data raw) {
 	Acceleration_Y_Raw *ay_raw = (Acceleration_Y_Raw *)raw.data;
-	ay_raw->one = *(((uint16_t *)buffer)+ACCELERATION_Y_OFFSET);
+	ay_raw->one = spi->get_data(XMEGA2, Y_ACCELERATION_INDEX);
 }

--- a/CentralComputing/Sensor_Aux/Acceleration_Y.h
+++ b/CentralComputing/Sensor_Aux/Acceleration_Y.h
@@ -1,10 +1,11 @@
 #ifndef ACCELERATION_Y_H
 #define ACCELERATION_Y_H
 #include "../Data.h"
+#include "../Sensor.h"
 
 struct Acceleration_Y_Raw {
 	uint16_t one;
 };
 
-void acceleration_y_parse(uint8_t * buffer, Arbitrary_Data raw);
+void acceleration_y_parse(Spi * spi, Arbitrary_Data raw);
 #endif

--- a/CentralComputing/Sensor_Aux/Acceleration_Z.cpp
+++ b/CentralComputing/Sensor_Aux/Acceleration_Z.cpp
@@ -4,7 +4,7 @@
 
 using namespace std;
 
-void acceleration_z_parse(uint8_t * buffer, Arbitrary_Data raw) {
+void acceleration_z_parse(Spi * spi, Arbitrary_Data raw) {
 	Acceleration_Z_Raw *az_raw = (Acceleration_Z_Raw *)raw.data;
-	az_raw->one = *(((uint16_t *)buffer) + ACCELERATION_Z_OFFSET);
+	az_raw->one = spi->get_data(XMEGA2, Z_ACCELERATION_INDEX);
 }

--- a/CentralComputing/Sensor_Aux/Acceleration_Z.h
+++ b/CentralComputing/Sensor_Aux/Acceleration_Z.h
@@ -1,10 +1,11 @@
 #ifndef ACCELERATION_Z_H
 #define ACCELERATION_Z_H
 #include "../Data.h"
+#include "../Sensor.h"
 
 struct Acceleration_Z_Raw {
 	uint16_t one;
 };
 
-void acceleration_z_parse(uint8_t * buffer, Arbitrary_Data raw);
+void acceleration_z_parse(Spi * spi, Arbitrary_Data raw);
 #endif

--- a/CentralComputing/Sensor_Aux/Brake_Pressure.cpp
+++ b/CentralComputing/Sensor_Aux/Brake_Pressure.cpp
@@ -4,7 +4,7 @@
 
 using namespace std;
 
-void brake_pressure_parse(uint8_t * buffer, Arbitrary_Data raw) {
+void brake_pressure_parse(Spi * spi, Arbitrary_Data raw) {
 	Brake_Pressure_Raw * brake_raw = (Brake_Pressure_Raw *)raw.data;
-	brake_raw->brake_pressure = *(((uint16_t *)buffer) + BRAKE_PRESSURE_OFFSET);
+	brake_raw->brake_pressure = spi->get_data(XMEGA1, BRAKE_PRESSURE_INDEX);
 }

--- a/CentralComputing/Sensor_Aux/Brake_Pressure.h
+++ b/CentralComputing/Sensor_Aux/Brake_Pressure.h
@@ -1,10 +1,11 @@
 #ifndef BRAKE_PRESSURE_H
 #define BRAKE_PRESSURE_H
 #include "../Data.h"
+#include "../Sensor.h"
 
 struct Brake_Pressure_Raw {
 	uint16_t brake_pressure;
 };
 
-void brake_pressure_parse(uint8_t * buffer, Arbitrary_Data raw);
+void brake_pressure_parse(Spi * spi, Arbitrary_Data raw);
 #endif

--- a/CentralComputing/Sensor_Aux/Current.cpp
+++ b/CentralComputing/Sensor_Aux/Current.cpp
@@ -4,7 +4,7 @@
 
 using namespace std;
 
-void current_parse(uint8_t * buffer, Arbitrary_Data raw) {
+void current_parse(Spi * spi, Arbitrary_Data raw) {
 	Current_Raw * cur_raw = (Current_Raw *)raw.data;
-	cur_raw->current = *(((uint16_t *)buffer) + CURRENT_OFFSET);
+	cur_raw->current = spi->get_data(XMEGA2, CURRENT_INDEX_1);
 }

--- a/CentralComputing/Sensor_Aux/Current.h
+++ b/CentralComputing/Sensor_Aux/Current.h
@@ -1,10 +1,11 @@
 #ifndef CURRENT_H
 #define CURRENT_H
 #include "../Data.h"
+#include "../Sensor.h"
 
 struct Current_Raw {
 	uint16_t current;
 };
 
-void current_parse(uint8_t * buffer, Arbitrary_Data raw);
+void current_parse(Spi * spi, Arbitrary_Data raw);
 #endif

--- a/CentralComputing/Sensor_Aux/Distance.cpp
+++ b/CentralComputing/Sensor_Aux/Distance.cpp
@@ -23,11 +23,10 @@ Arbitrary_Data distance_calculation(Arbitrary_Data raw) {
   return calculated;                                                        //Copy out calculated to the calling function
 }
 
-void distance_parse(uint8_t * buffer, Arbitrary_Data raw) {
+void distance_parse(Spi * spi, Arbitrary_Data raw) {
   Distance_Raw * d_raw = (Distance_Raw *)raw.data;                           // Convert the raw data into a useable struct
-  // These are placeholders for now. They need to be updated with real values
-  d_raw->tape_count = (int) *(buffer + TAPE_OFFSET);                         // Fetch the tape count from the buffer and store
-  d_raw->encoder_count = (int) *(buffer  + ENCODER_COUNT_OFFSET);            // Fetch the encoder count from the buffer and store 
+  d_raw->tape_count = spi->get_data(XMEGA2, TAPE_COUNT_INDEX);
+  d_raw->encoder_count = spi->get_data(XMEGA1, ENCODER_COUNT_INDEX);
 }
 
 

--- a/CentralComputing/Sensor_Aux/Distance.h
+++ b/CentralComputing/Sensor_Aux/Distance.h
@@ -1,9 +1,10 @@
 #ifndef DISTANCE_H
 #define DISTANCE_H
 #include "../Data.h"
+#include "../Sensor.h"
 struct Distance_Raw {
-  int tape_count;
-  int encoder_count;
+  uint32_t tape_count;
+  uint32_t encoder_count;
 };
 
 struct Distance_Calc {
@@ -11,6 +12,6 @@ struct Distance_Calc {
 };
 
 Arbitrary_Data distance_calculation(Arbitrary_Data raw);
-void distance_parse(uint8_t * buffer, Arbitrary_Data raw);
+void distance_parse(Spi * spi, Arbitrary_Data raw);
 
 #endif // DISTANCE_H

--- a/CentralComputing/Sensor_Aux/Ride_Height.cpp
+++ b/CentralComputing/Sensor_Aux/Ride_Height.cpp
@@ -4,9 +4,9 @@
 
 using namespace std;
 
-void ride_height_parse(uint8_t * buffer, Arbitrary_Data raw) {
+void ride_height_parse(Spi * spi , Arbitrary_Data raw) {
   Ride_Height_Raw * rh_raw = (Ride_Height_Raw *) raw.data;
-  rh_raw->left = *(((uint16_t *)buffer) + RIDE_HEIGHT_OFFSET);
-  rh_raw->middle = *(((uint16_t *)buffer) + RIDE_HEIGHT_OFFSET + 1);
-  rh_raw->right = *(((uint16_t *)buffer) + RIDE_HEIGHT_OFFSET + 2);
+  rh_raw->left = spi->get_data(XMEGA2, RIDE_HEIGHT_INDEX_1);
+  rh_raw->middle = spi->get_data(XMEGA2, RIDE_HEIGHT_INDEX_2);
+  rh_raw->right = spi->get_data(XMEGA2, RIDE_HEIGHT_INDEX_3);
 }

--- a/CentralComputing/Sensor_Aux/Ride_Height.h
+++ b/CentralComputing/Sensor_Aux/Ride_Height.h
@@ -1,6 +1,7 @@
 #ifndef RIDE_HEIGHT_H
 #define RIDE_HEIGHT_H
 #include "../Data.h"
+#include "../Sensor.h"
 
 struct Ride_Height_Raw {
   uint16_t left;
@@ -8,5 +9,5 @@ struct Ride_Height_Raw {
   uint16_t right; 
 };
 
-void ride_height_parse(uint8_t * buffer, Arbitrary_Data raw);
+void ride_height_parse(Spi * spi, Arbitrary_Data raw);
 #endif

--- a/CentralComputing/Sensor_Aux/Temperature.cpp
+++ b/CentralComputing/Sensor_Aux/Temperature.cpp
@@ -4,11 +4,12 @@
 
 using namespace std;
 
-void temperature_parse(uint8_t * buffer, Arbitrary_Data raw) {
+void temperature_parse(Spi * spi, Arbitrary_Data raw) {
   Temperature_Raw * t_raw = (Temperature_Raw *)raw.data;
-  t_raw->brake_temp = *(buffer + TEMPERATURE_OFFSET);
-  t_raw->battery_temp = *(buffer + TEMPERATURE_OFFSET + 1);
-  t_raw->cpu_temp = *(buffer + TEMPERATURE_OFFSET + 2);
-  t_raw->motor_temp = *(buffer + TEMPERATURE_OFFSET + 3);
-  t_raw->wheel_temp = *(buffer + TEMPERATURE_OFFSET + 4);
+  t_raw->brake_temp = spi->get_data(XMEGA2, THERMOCOUPLE_INDEX_1);
+  t_raw->battery_temp = spi->get_data(XMEGA2, THERMOCOUPLE_INDEX_2);
+  t_raw->cpu_temp = spi->get_data(XMEGA2, THERMOCOUPLE_INDEX_3);
+  t_raw->motor_temp = spi->get_data(XMEGA2, THERMOCOUPLE_INDEX_4);
+  t_raw->wheel_temp = spi->get_data(XMEGA2, THERMOCOUPLE_INDEX_5);
+
 }

--- a/CentralComputing/Sensor_Aux/Temperature.h
+++ b/CentralComputing/Sensor_Aux/Temperature.h
@@ -1,6 +1,7 @@
 #ifndef TEMPERATURE_H
 #define TEMPERATURE_H
 #include "../Data.h"
+#include "../Sensor.h"
 
 struct Temperature_Raw {
   uint8_t brake_temp;
@@ -10,6 +11,6 @@ struct Temperature_Raw {
   uint8_t wheel_temp;
 };
 
-void temperature_parse(uint8_t * buffer, Arbitrary_Data raw);
+void temperature_parse(Spi * spi , Arbitrary_Data raw);
 
 #endif

--- a/CentralComputing/Sensor_Aux/Velocity.cpp
+++ b/CentralComputing/Sensor_Aux/Velocity.cpp
@@ -25,7 +25,8 @@ Arbitrary_Data velocity_calculation(Arbitrary_Data raw) {
   return calculated;                                                        //Copy out calculated to the calling function
 }
 
-void velocity_parse(uint8_t * buffer, Arbitrary_Data raw) {
+void velocity_parse(Spi * spi, Arbitrary_Data raw) {
   Velocity_Raw * v_raw = (Velocity_Raw *)raw.data;                           // Convert the raw data into a useable struct
-  // These are placeholders for now. They need to be updated with real values
-  v_raw->rpm = (int) *(buffer + RPM_OFFSET);                     }
+  v_raw->rpm = spi->get_data(XMEGA1, ENCODER_RPM_INDEX);
+  
+}

--- a/CentralComputing/Sensor_Aux/Velocity.h
+++ b/CentralComputing/Sensor_Aux/Velocity.h
@@ -1,10 +1,10 @@
 #ifndef VELOCITY_h
 #define VELOCITY_h
 #include "../Data.h"
+#include "../Sensor.h"
 
-struct Velocity_Raw{
-	
-	int rpm;
+struct Velocity_Raw{	
+	uint32_t rpm;
 };
 
 struct Velocity_Calc{
@@ -12,7 +12,7 @@ struct Velocity_Calc{
 };
 
 Arbitrary_Data velocity_calculation(Arbitrary_Data raw);
-void velocity_parse(uint8_t * buffer, Arbitrary_Data raw);
+void velocity_parse(Spi * spi, Arbitrary_Data raw);
 
 #endif // VELOCITY_H
 

--- a/CentralComputing/Xmega-sim.cpp
+++ b/CentralComputing/Xmega-sim.cpp
@@ -7,4 +7,8 @@ Xmega::Xmega(Spi * s) {
 
 void Xmega::write(Xmega_Command command) {
 }
+
+Xmega_Command Xmega::transfer(){
+  return X_NONE;
+}
 #endif

--- a/CentralComputing/Xmega-sim.cpp
+++ b/CentralComputing/Xmega-sim.cpp
@@ -1,12 +1,8 @@
 #ifdef SIM
 #include "Xmega.h"
 
-Xmega::Xmega() {
+Xmega::Xmega(Spi * s) {
 
-}
-
-uint8_t * Xmega::read() {
-  return 0;
 }
 
 void Xmega::write(Xmega_Command command) {

--- a/CentralComputing/Xmega.cpp
+++ b/CentralComputing/Xmega.cpp
@@ -1,14 +1,24 @@
 #ifndef SIM
 #include "Xmega.h"
 
-Xmega::Xmega() {
+Xmega::Xmega(Spi * s) : spi(s){
 
 }
 
-uint8_t * Xmega::read() {
-  return 0;
-}
 
 void Xmega::write(Xmega_Command command) {
+  q.push(command);
+}
+
+Xmega_Command Xmega::transfer() {
+  Xmega_Command command;
+  if(q.empty())
+    command = X_NONE;
+  else {
+    command = q.front();
+    q.pop();
+  }
+  //TODO construct transfer object, call spi->transfer(transfer)
+
 }
 #endif

--- a/CentralComputing/Xmega.cpp
+++ b/CentralComputing/Xmega.cpp
@@ -20,5 +20,7 @@ Xmega_Command Xmega::transfer() {
   }
   //TODO construct transfer object, call spi->transfer(transfer)
 
+  return command;
+
 }
 #endif

--- a/CentralComputing/Xmega.h
+++ b/CentralComputing/Xmega.h
@@ -2,25 +2,20 @@
 #define XMEGA_h
 
 #include "Spi.h"
+#include <queue>
 
 enum Xmega_Command {
   // TODO list all possible commands
-  X_PLACEHOLDER
+  X_NONE,
+  X_PLACEHOLDER,
 };
 
 class Xmega {
   public:
     /**
     * Sets up connection to XMEGA
-    * Creates internal data buffers
     **/
-    Xmega();
-
-    /**
-    * Reads data from Spi
-    * @return a buffer representing all the most recent sensor data
-    **/
-    uint8_t * read();
+    Xmega(Spi * s);
 
     /**
     * Writes a command to the Xmegas
@@ -30,17 +25,21 @@ class Xmega {
     void write(Xmega_Command command);
 
 
+    /**
+    * Updates SPI and sends a command from the command queue
+    * @return the command to be run
+    **/ 
+    Xmega_Command transfer();
+
+
   private:
     #ifdef SIM
 
     #else
 
       Spi * spi;
-      /**
-      * updates the internal buffers and sends the most recent command
-      */
-      void update();
-      uint8_t * buffer;
+      std::queue<Xmega_Command> q;
+
     #endif
     
 };

--- a/CentralComputing/Xmega.h
+++ b/CentralComputing/Xmega.h
@@ -1,5 +1,5 @@
 #ifndef XMEGA_H
-#define XMEGA_h
+#define XMEGA_H
 
 #include "Spi.h"
 #include <queue>
@@ -9,6 +9,7 @@ enum Xmega_Command {
   X_NONE,
   X_PLACEHOLDER,
 };
+
 
 class Xmega {
   public:
@@ -31,6 +32,10 @@ class Xmega {
     **/ 
     Xmega_Command transfer();
 
+    std::string x_command_to_string(Xmega_Command c) {
+       std::string x_strings[] = {"None", "Placeholder"};
+       return x_strings[c];
+    };
 
   private:
     #ifdef SIM


### PR DESCRIPTION
Xmega is changed
That layer of abstraction
I am good at git

Xmega class now handles only writing--Sensor class interfaces directly with SPI class in non-simulation mode.  This removes needless abstraction within Xmega class, but requires that all parse_functions take an SPI reference as a parameter. Need to configure some things for actual work with pod.