### PR TITLE
Singleton Simulator

### DIFF
--- a/CentralComputing/NetworkManager.hpp
+++ b/CentralComputing/NetworkManager.hpp
@@ -34,8 +34,9 @@ enum Network_Command_ID {
   ENABLE_MOTOR = 6,
   DISABLE_MOTOR = 7,
   SET_MOTOR_SPEED = 8,
-  ACTIVATE_BRAKE_MAGNET = 9,
-  DEACTIVATE_BRAKE_MAGNET = 10 
+  ENABLE_BRAKE = 9,
+  DISABLE_BRAKE = 10,
+  SET_BRAKE_PRESSURE = 11,
 };
 
 //enum specifying what data is sent

--- a/CentralComputing/Pod_State.cpp
+++ b/CentralComputing/Pod_State.cpp
@@ -18,8 +18,9 @@ Pod_State::Pod_State()
   transition_map[NetworkManager::ENABLE_MOTOR] = &Pod_State::no_transition;
   transition_map[NetworkManager::DISABLE_MOTOR] = &Pod_State::no_transition;
   transition_map[NetworkManager::SET_MOTOR_SPEED] = &Pod_State::no_transition;
-  transition_map[NetworkManager::ACTIVATE_BRAKE_MAGNET] = &Pod_State::no_transition;
-  transition_map[NetworkManager::DEACTIVATE_BRAKE_MAGNET] = &Pod_State::no_transition;
+  transition_map[NetworkManager::ENABLE_BRAKE] = &Pod_State::no_transition;
+  transition_map[NetworkManager::DISABLE_BRAKE] = &Pod_State::no_transition;
+  transition_map[NetworkManager::SET_BRAKE_PRESSURE] = &Pod_State::no_transition;
   steady_state_map[ST_SAFE_MODE] = &Pod_State::steady_safe_mode;
   steady_state_map[ST_FUNCTIONAL_TEST] = &Pod_State::steady_functional;
   steady_state_map[ST_LOADING] = &Pod_State::steady_loading;
@@ -187,12 +188,13 @@ void Pod_State::steady_functional(std::shared_ptr<NetworkManager::Network_Comman
 		case NetworkManager::SET_MOTOR_SPEED:
       motor.set_throttle(command->value * 4); //value is 0-250, set_throttle expects 0-1000
 			break;
-  	case NetworkManager::ACTIVATE_BRAKE_MAGNET:
+  	case NetworkManager::ENABLE_BRAKE:
       //activate brakes
 			break;
-		case NetworkManager::DEACTIVATE_BRAKE_MAGNET:
+		case NetworkManager::DISABLE_BRAKE:
       //deactivate brakes
 			break;
+		case NetworkManager::SET_BRAKE_PRESSURE:
     default:
       break;
 	}

--- a/CentralComputing/Simulator.cpp
+++ b/CentralComputing/Simulator.cpp
@@ -1,7 +1,10 @@
 #include "Simulator.hpp"
 
 using namespace Utils;
-Simulator::Simulator(const char * logfile) : logpath(logfile) {
+
+Simulator SimulatorManager::sim;
+
+Simulator::Simulator() {
   //TODO set up internal variables
 }
 

--- a/CentralComputing/Simulator.hpp
+++ b/CentralComputing/Simulator.hpp
@@ -5,15 +5,13 @@
 #include "NetworkManager.hpp"
 #include "Pod_State.h"
 using namespace std;
-
 class Simulator {
  
   public:
     /**
      * Creates a command simulator object
-     * @param logfile filepath where pod network output will be sent to or dev/null if null
      */
-    Simulator(const char * logfile);
+    Simulator();
 
 
     /**
@@ -41,7 +39,6 @@ class Simulator {
     void disconnect();
 
 
-    const char * logpath; //logpath file
 
     Pod_State::E_States current_state; //current state of the pod as read by the network controller
 
@@ -54,5 +51,8 @@ class Simulator {
     //TODO:
     //Add brake status, motor status
 };
+namespace SimulatorManager {
+  extern Simulator sim;
+}
 
 #endif //SIMULATOR_HPP

--- a/CentralComputing/tests/PodTest.cpp
+++ b/CentralComputing/tests/PodTest.cpp
@@ -17,15 +17,14 @@ class PodTest : public ::testing::Test
     pod->ready.wait();
    
     EXPECT_EQ(pod->state_machine->get_current_state(), Pod_State::E_States::ST_SAFE_MODE);
-    simulator = std::make_shared<Simulator>(nullptr);
-    EXPECT_TRUE(simulator->sim_connect("127.0.0.1", "8800"));//TODO make these variables somewhere
+    EXPECT_TRUE(SimulatorManager::sim.sim_connect("127.0.0.1", "8800"));//TODO make these variables somewhere
     NetworkManager::connected.wait();
     print(LogLevel::LOG_INFO, "Done setting up test, running test\n");
   }
 
   virtual void TearDown() {
     print(LogLevel::LOG_INFO, "Test finished, tearing down\n");
-    simulator->disconnect();
+    SimulatorManager::sim.disconnect();
     pod->stop();
     pod_thread.join();
   }
@@ -42,7 +41,7 @@ class PodTest : public ::testing::Test
     command->id = id;
     command->value = value;
     pod->processing_command.reset();
-    EXPECT_TRUE(simulator->send_command(command));
+    EXPECT_TRUE(SimulatorManager::sim.send_command(command));
     pod->processing_command.wait();
   }
   /*
@@ -66,7 +65,6 @@ class PodTest : public ::testing::Test
 
   std::shared_ptr<Pod> pod;
   std::thread pod_thread;
-  std::shared_ptr<Simulator> simulator;
 };
 
 

--- a/CentralComputing/tests/PodTest.cpp
+++ b/CentralComputing/tests/PodTest.cpp
@@ -30,27 +30,12 @@ class PodTest : public ::testing::Test
     pod_thread.join();
   }
 
+  
   /*
-   * Handy helper function for testing state transitions
-   * @param id the command to run
-   * @param state the target state the command will bring you to
-   * @param allow true if this transition should be allowed, false otherwises
+   * Helper function to send a command using the simulator
+   * @param id the id of the command to run
+   * @param value the value for the command
    */
-  void MoveState(NetworkManager::Network_Command_ID id, Pod_State::E_States state, bool allow) {
-    auto command = std::make_shared<NetworkManager::Network_Command>();
-    command->id = id;
-    command->value = 0;
-    Pod_State::E_States start_state = pod->state_machine->get_current_state();
-    pod->processing_command.reset();
-    EXPECT_TRUE(simulator->send_command(command));
-    pod->processing_command.wait();
-    if(allow) {
-      EXPECT_EQ(pod->state_machine->get_current_state(), state);
-    } else {
-      EXPECT_EQ(pod->state_machine->get_current_state(), start_state);
-    }
-  }
-
   void SendCommand(NetworkManager::Network_Command_ID id, uint8_t value) {
 
     auto command = std::make_shared<NetworkManager::Network_Command>();
@@ -60,6 +45,24 @@ class PodTest : public ::testing::Test
     EXPECT_TRUE(simulator->send_command(command));
     pod->processing_command.wait();
   }
+  /*
+   * Handy helper function for testing state transitions
+   * @param id the command to run
+   * @param state the target state the command will bring you to
+   * @param allow true if this transition should be allowed, false otherwises
+   */
+  void MoveState(NetworkManager::Network_Command_ID id, Pod_State::E_States state, bool allow) {
+
+    auto start_state = pod->state_machine->get_current_state();
+    SendCommand(id, 0);
+
+    if(allow) {
+      EXPECT_EQ(pod->state_machine->get_current_state(), state);
+    } else {
+      EXPECT_EQ(pod->state_machine->get_current_state(), start_state);
+    }
+  }
+
 
   std::shared_ptr<Pod> pod;
   std::thread pod_thread;


### PR DESCRIPTION
This takes the Simulator class and makes it a Singleton. This is how we should do the Brakes/Motor classes as well, so we can access the brakes and motor values from anywhere we want without passing a pointer around.