### PR TITLE
Brake and motor activation

### DIFF
--- a/CentralComputing/Brakes.cpp
+++ b/CentralComputing/Brakes.cpp
@@ -6,10 +6,14 @@ Brakes::Brakes(){
 }
 
 void Brakes::enable_brakes() {
+	set_enable(true);
+	enabled = true;
   print(LogLevel::LOG_DEBUG, "Brakes Enabled\n");
 }
 
 void Brakes::disable_brakes() {
+	set_enable(false);
+	enabled = false;
   print(LogLevel::LOG_DEBUG, "Brakes Disabled\n");
 }
 

--- a/CentralComputing/Pod_State.cpp
+++ b/CentralComputing/Pod_State.cpp
@@ -168,14 +168,18 @@ void Pod_State::ST_Launch_Ready() {
 }
 
 void Pod_State::ST_Flight_Accel() {
+	brakes.disable_brakes();
+	motor.enable_motors();
   print(LogLevel::LOG_EDEBUG, "STATE : %s\n", get_current_state_string().c_str());
 }
 
 void Pod_State::ST_Flight_Coast() {
+	motor.disable_motors();
   print(LogLevel::LOG_EDEBUG, "STATE : %s\n", get_current_state_string().c_str());
 }
 
 void Pod_State::ST_Flight_Brake() {
+	brakes.enable_brakes();
   print(LogLevel::LOG_EDEBUG, "STATE : %s\n", get_current_state_string().c_str());
 }
 

--- a/CentralComputing/Pod_State.h
+++ b/CentralComputing/Pod_State.h
@@ -3,6 +3,7 @@
 
 #include "StateMachineCompact/StateMachine.h"
 #include "Motor.hpp"
+#include "Brakes.hpp"
 #include "NetworkManager.hpp"
 #include <iostream>
 #include <string>
@@ -103,6 +104,7 @@ class Pod_State : public StateMachine {
     }
 
     Motor motor;
+    Brakes brakes;
 		
 	private:
     std::map<NetworkManager::Network_Command_ID, transition_function> transition_map; 

--- a/CentralComputing/tests/StateTest.cpp
+++ b/CentralComputing/tests/StateTest.cpp
@@ -217,7 +217,9 @@ TEST_F(PodTest, FlightAccelFailures) {
   MoveState(NetworkManager::Network_Command_ID::TRANS_LOADING, Pod_State::E_States::ST_LOADING, true);
   MoveState(NetworkManager::Network_Command_ID::TRANS_LAUNCH_READY, Pod_State::E_States::ST_LAUNCH_READY, true);
   MoveState(NetworkManager::Network_Command_ID::LAUNCH, Pod_State::E_States::ST_FLIGHT_ACCEL, true);
+  EXPECT_EQ(pod->state_machine->motor.is_enabled(), true);
 
+  EXPECT_EQ(pod->state_machine->brakes.is_enabled(), false);
   MoveState(NetworkManager::Network_Command_ID::TRANS_SAFE_MODE, Pod_State::E_States::ST_SAFE_MODE, false);
   MoveState(NetworkManager::Network_Command_ID::TRANS_LOADING, Pod_State::E_States::ST_LOADING, false);
   MoveState(NetworkManager::Network_Command_ID::TRANS_LAUNCH_READY, Pod_State::E_States::ST_LAUNCH_READY, false);
@@ -233,6 +235,8 @@ TEST_F(PodTest, FlightCoastFailures) {
   MoveState(NetworkManager::Network_Command_ID::LAUNCH, Pod_State::E_States::ST_FLIGHT_ACCEL, true);
   MoveState(NetworkManager::Network_Command_ID::TRANS_FLIGHT_COAST, Pod_State::E_States::ST_FLIGHT_COAST, true);
   
+  EXPECT_EQ(pod->state_machine->motor.is_enabled(), false);
+  EXPECT_EQ(pod->state_machine->brakes.is_enabled(), false);
   MoveState(NetworkManager::Network_Command_ID::TRANS_SAFE_MODE, Pod_State::E_States::ST_SAFE_MODE, false);
   MoveState(NetworkManager::Network_Command_ID::TRANS_LOADING, Pod_State::E_States::ST_LOADING, false);
   MoveState(NetworkManager::Network_Command_ID::TRANS_LAUNCH_READY, Pod_State::E_States::ST_LAUNCH_READY, false);
@@ -248,7 +252,9 @@ TEST_F(PodTest, FlightBrakeFailures) {
   MoveState(NetworkManager::Network_Command_ID::LAUNCH, Pod_State::E_States::ST_FLIGHT_ACCEL, true);
   MoveState(NetworkManager::Network_Command_ID::TRANS_FLIGHT_COAST, Pod_State::E_States::ST_FLIGHT_COAST, true);
   MoveState(NetworkManager::Network_Command_ID::TRANS_FLIGHT_BRAKE, Pod_State::E_States::ST_FLIGHT_BRAKE, true);
+  EXPECT_EQ(pod->state_machine->brakes.is_enabled(), true);
   
+  EXPECT_EQ(pod->state_machine->motor.is_enabled(), false);
   MoveState(NetworkManager::Network_Command_ID::TRANS_LOADING, Pod_State::E_States::ST_LOADING, false);
   MoveState(NetworkManager::Network_Command_ID::TRANS_LAUNCH_READY, Pod_State::E_States::ST_LAUNCH_READY, false);
   MoveState(NetworkManager::Network_Command_ID::TRANS_FUNCTIONAL_TEST, Pod_State::E_States::ST_FUNCTIONAL_TEST, false);


### PR DESCRIPTION
Motors go vroom
Brakes go screee
I think this is right
But don't trust me.

Activates the brakes and motors depending on what the pod should be doing. I got all the test cases to pass. I had to add to the brakes.cpp class so that enabling/disabling the brakes would update the state of brakes.is_enabled()