### PR TITLE
Pod4 devops

### DIFF
--- a/CentralComputing/Makefile
+++ b/CentralComputing/Makefile
@@ -21,7 +21,9 @@ CFLAGS_SIM 	:= -O0 $(WARNINGS) -g -std=c++11 -c -MMD -MP $(INCLUDE_DIRS) -D_GNU_
 CFLAGS_BBB      := -DBBB
 
 #Set up linker
-LDFLAGS := -pthread -lm -static-libgcc -static-libstdc++ 
+LDFLAGS := -pthread -lm #-static-libgcc -static-libstdc++ 
+# The 'static' flags might be necessary if the cross compiler and BBB have different versions of the libgcc and libstdc++ libraries. 
+# This is why these flags were intially included, but now the BBBs are running newer software such that these are no longer needed.
 LD_TEST_NORM := ${LIB_DIR}/libgtest.a
 LD_TEST_ARM  := ${LIB_DIR}/libgtest-arm.a
 LD_NORM := $(CXX_NORM)

--- a/CentralComputing/MotionModel.cpp
+++ b/CentralComputing/MotionModel.cpp
@@ -75,5 +75,9 @@ std::shared_ptr<StateSpace> MotionModel::refresh(){
 
 //get StateSpace object
 std::shared_ptr<StateSpace> MotionModel::refresh_sim() {
+  #ifdef SIM
   return SimulatorManager::sim.sim_get_motion();
+  #else
+  return empty_data();
+  #endif
 }

--- a/CentralComputing/Simulator.cpp
+++ b/CentralComputing/Simulator.cpp
@@ -1,3 +1,4 @@
+#ifdef SIM // Only compile if building test executable
 #include "Simulator.hpp"
 
 using namespace Utils;
@@ -175,3 +176,4 @@ void Simulator::reset_motion() {
     timeLast = -1;
 
 }
+#endif

--- a/CentralComputing/tests/AutoTests.cpp
+++ b/CentralComputing/tests/AutoTests.cpp
@@ -1,3 +1,4 @@
+#ifdef SIM // Only compile if building test executable
 #include "PodTest.cpp"
 
 TEST_F(PodTest, AutomaticTransitionBasic) {
@@ -19,4 +20,4 @@ TEST_F(PodTest, AutomaticTransitionBasic) {
   EXPECT_EQ(pod->state_machine->get_current_state(), Pod_State::E_States::ST_FLIGHT_BRAKE);
 
 }
-
+#endif

--- a/CentralComputing/tests/ConfiguratorTest.cpp
+++ b/CentralComputing/tests/ConfiguratorTest.cpp
@@ -1,3 +1,4 @@
+#ifdef SIM // Only compile if building test executable
 #include "PodTest.cpp"
 #include <string>
 using namespace std;
@@ -47,3 +48,4 @@ TEST_F(PodTest, ConfigManagerTimeouts) {
   EXPECT_EQ(std::stoll(val), SourceManager::MM.refresh_timeout());
 
 }
+#endif

--- a/CentralComputing/tests/MotorTest.cpp
+++ b/CentralComputing/tests/MotorTest.cpp
@@ -1,3 +1,4 @@
+#ifdef SIM // Only compile if building test executable
 #include "PodTest.cpp"
 
 void check_test_eq(std::string file, std::string val);
@@ -52,3 +53,4 @@ TEST_F(PodTest, MotorTest) {
   EXPECT_EQ(pod->state_machine->motor.get_throttle(), 0);
 
 }
+#endif

--- a/CentralComputing/tests/PodTest.cpp
+++ b/CentralComputing/tests/PodTest.cpp
@@ -1,3 +1,4 @@
+#ifdef SIM // Only compile if building test executable
 #include "Pod.h"
 #include "Simulator.hpp"
 
@@ -66,3 +67,4 @@ class PodTest : public ::testing::Test
   std::shared_ptr<Pod> pod;
   std::thread pod_thread;
 };
+#endif

--- a/CentralComputing/tests/StateTest.cpp
+++ b/CentralComputing/tests/StateTest.cpp
@@ -1,3 +1,4 @@
+#ifdef SIM // Only compile if building test executable
 #include "PodTest.cpp"
 
 
@@ -325,3 +326,4 @@ TEST_F(PodTest, FlightBrakeFailures) {
   	MoveState(NetworkManager::Network_Command_ID::TRANS_FLIGHT_BRAKE, Pod_State::E_States::ST_FLIGHT_BRAKE, false);
   }
 
+#endif

--- a/CentralComputing/tests/UtilsTest.cpp
+++ b/CentralComputing/tests/UtilsTest.cpp
@@ -1,3 +1,4 @@
+#ifdef SIM // Only compile if building test executable
 #include "Utils.h"
 #include "Pod.h"
 #include "Event.hpp"
@@ -113,4 +114,4 @@ TEST(UtilsTest, GPIOToggleTest) {
 
 }
 
-
+#endif

--- a/CentralComputing/tests/VelocityTest.cpp
+++ b/CentralComputing/tests/VelocityTest.cpp
@@ -1,5 +1,7 @@
+#ifdef SIM // Only compile if building test executable
 #include "PodTest.cpp"
 
 TEST_F(PodTest, VelocitySanity) {
     
 }
+#endif


### PR DESCRIPTION
Time spent on Hyperloop
is never ever wasted 
But I need to study


Adding `#ifdef SIM` that exclude simulation/testing code from being compiled into normal executables. Slightly speeds up compilation time of non-sim executables

Removed some unnecessary compiler flags from the Makefile. Slightly speeds up compilation time, and reduces file size. 

Overall these are pretty pedantic changes, but make development a little quicker.