### PR TITLE
Can compile with Address Sanitizer

### DIFF
--- a/CentralComputing/Makefile
+++ b/CentralComputing/Makefile
@@ -21,8 +21,7 @@ CFLAGS_RELEASE 	:= -O2 $(WARNINGS) -g -std=c++11 -c -MMD -MP $(INCLUDE_DIRS) -D_
 CFLAGS_DEBUG   	:= -O0 $(WARNINGS) -g -std=c++11 -c -MMD -MP $(INCLUDE_DIRS) -D_GNU_SOURCE -pthread -DDEBUG 
 CFLAGS_SIM 	:= -O0 $(WARNINGS) -g -std=c++11 -c -MMD -MP $(INCLUDE_DIRS) -D_GNU_SOURCE -pthread -DDEBUG -DSIM 
 CFLAGS_BBB      := -DBBB
-CFLAGS_NORM     := -fsanitize=thread -fPIE -pie
-
+CFLAGS_NORM     := 
 #Set up linker
 LDFLAGS := -pthread -lm  #-static-libgcc -static-libstdc++ 
 # The 'static' flags might be necessary if the cross compiler and BBB have different versions of the libgcc and libstdc++ libraries. 
@@ -30,7 +29,7 @@ LDFLAGS := -pthread -lm  #-static-libgcc -static-libstdc++
 # However, the 'static' flags will likely not work with any of the Sanitizers
 LD_TEST_NORM := ${LIB_DIR}/libgtest.a
 LD_TEST_ARM  := ${LIB_DIR}/libgtest-arm.a
-LD_NORM := $(CXX_NORM) -fsanitize=thread
+LD_NORM := $(CXX_NORM)
 LD_BBB  := $(CXX_BBB)
 
 # Define all executables
@@ -45,7 +44,7 @@ ARM_COMPILER_EXISTS := $(shell command -v $(CXX_BBB) 2> /dev/null)
 
 
 .PHONY: all
-all : msg mkdir_obj ${LIB_DIR}/gtest-all.o ${LIB_DIR}/gtest-all-arm.o msg_d $(POD_D) msg_s $(POD_T)
+all : msg mkdir_obj ${LIB_DIR}/gtest-all.o ${LIB_DIR}/gtest-all-arm.o msg_d $(POD_D)-tsan msg_s $(POD_T)-tsan
 	$(info  =   ___ _   _  ___ ___ ___  ___ ___  )
 	$(info	=  / __| | | |/ __/ __/ _ \/ __/ __| )
 	${info	=  \__ \ |_| | (_| (_|  __/\__ \__ \ }
@@ -133,6 +132,14 @@ msg_p :
 #####
 # build
 #####
+$(POD)-tsan : LD_NORM := $(LD_NORM) -fsanitize=thread
+$(POD)-tsan : CXX_NORM := $(CXX_NORM) -fsanitize=thread -fPIE -pie
+$(POD)-tsan : $(POD)  #JUMP TO POD to continue compiling
+
+$(POD)-asan : LD_NORM := $(LD_NORM) -fsanitize=address
+$(POD)-asan : CXX_NORM := $(CXX_NORM) -fsanitize=address 
+$(POD)-asan : $(POD)  #JUMP TO POD to continue compiling
+
 $(POD) : CXX 	= $(CXX_NORM)
 $(POD) : CFLAGS = $(CFLAGS_RELEASE) $(CFLAGS_NORM)
 $(POD) : LD  	= $(LD_NORM)
@@ -146,6 +153,14 @@ $(OBJ_DIR)/%-build.o : %.cpp
 #####
 # build-debug
 #####
+$(POD_D)-tsan : LD_NORM := $(LD_NORM) -fsanitize=thread
+$(POD_D)-tsan : CXX_NORM := $(CXX_NORM) -fsanitize=thread -fPIE -pie
+$(POD_D)-tsan : $(POD_D)  #JUMP TO POD to continue compiling
+
+$(POD_D)-asan : LD_NORM := $(LD_NORM) -fsanitize=address
+$(POD_D)-asan : CXX_NORM := $(CXX_NORM) -fsanitize=address 
+$(POD_D)-asan : $(POD_D)  #JUMP TO POD to continue compiling
+
 $(POD_D) : CXX		= $(CXX_NORM)
 $(POD_D) : CFLAGS  	= $(CFLAGS_DEBUG) $(CFLAGS_NORM)
 $(POD_D) : LD  		= $(LD_NORM)
@@ -159,6 +174,14 @@ $(OBJ_DIR)/%-build-debug.o : %.cpp
 #####
 # build-test
 #####
+$(POD_T)-tsan : LD_NORM := $(LD_NORM) -fsanitize=thread
+$(POD_T)-tsan : CXX_NORM := $(CXX_NORM) -fsanitize=thread -fPIE -pie
+$(POD_T)-tsan : $(POD_T)  #JUMP TO POD to continue compiling
+
+$(POD_T)-asan : LD_NORM := $(LD_NORM) -fsanitize=address
+$(POD_T)-asan : CXX_NORM := $(CXX_NORM) -fsanitize=address 
+$(POD_T)-asan : $(POD_T)  #JUMP TO POD to continue compiling
+
 $(POD_T) : CXX 		= $(CXX_NORM)
 $(POD_T) : CFLAGS  	= $(CFLAGS_SIM) $(CFLAGS_NORM)
 $(POD_T) : LD  		= $(LD_NORM)

--- a/CentralComputing/README.md
+++ b/CentralComputing/README.md
@@ -48,12 +48,13 @@ Specifically we use `cpplint.py` for easy linting of the most obvious errors. We
 
 
 # Building the project using the Makefile
+* Simply run `make` to get started. This will first compile the GTest library, and then the debug and test versions of the codebase.
 
 ### There are two types of executables
 * The `build` uses whatever default version of `g++` is installed on your system
 * The `cross` uses the `arm-linux-gnueabihf-g++` compiler and associated tool chain, so it can be compiled on a host machine and copied over to the 32-bit ARM Beaglebone Black
 
-### There are three modes
+### There are several compile time flag options
 * Release: 
   * defines `NDEBUG`, and compiles with optimizations
   * `build` and `cross`
@@ -63,14 +64,19 @@ Specifically we use `cpplint.py` for easy linting of the most obvious errors. We
 * Simulation:
   * defines `DEBUG` and `SIM`, and compiles without optimizations
   * `sbuild` and `scross`
+* BeagleBoneBlack:
+  * defines `BBB` when cross compiling, along with one of the above modes
+  * Note: No Sanitizers are used while compiling for the BBB. They are not implemented for 32-bit ARM.
 
-### Examples:
-* `make` will compile two things:
-  * `dbuild` and `sbuild`
-* `make [exe name]` will compile a specific executable
-  * `build` `dbuild` `sbuild` `cross` `dcross` `scross` are valid options
+### All make options
+* `make`, will compile the debug and test versions of the code, with the ThreadSanitizer already enabled.
+* `make build`, `make dbuild`, `make sbuild`, will compile the release, debug, or test versions, respectively. 
+  * Can run `make [exe_name]-tsan` or `make [exe_name]-asan` to build with those sanitizers. Be sure to run `make clean` when switching between sanitizer options.
+* `make cross`, `make dcross`, `make scross`, will cross compile the release, debug, or test versions, respectively. 
+  * There are no Sanitizers for 32-bit ARM. 
 
 ### Other commands:
 * `make clean` cleans up all executables and objects
+* `make clean_lib` cleans up the GTest library
 * `make push` uses scp to copy all `cross` executables over to a Beaglebone
 


### PR DESCRIPTION
Can now compile with -fsanitize=address, which is very useful in diagnosing SIGSEGV (segfault) errors. 

The Makefile is setup such that running `make` will still build the version of the code with TSan enabled, not ASan. This is because they are not compatible together, for some reason. 

To build with `ASan`, run `make clean` and compile any of the following build options with the asan flag enabled: `make sbuild-asan dbuild-asan build-asan` 

