### PR TITLE
Pod4 scenario

### DIFF
--- a/CentralComputing/ADCManager.cpp
+++ b/CentralComputing/ADCManager.cpp
@@ -20,5 +20,9 @@ std::shared_ptr<ADCData> ADCManager::refresh() {
 }
 
 std::shared_ptr<ADCData> ADCManager::refresh_sim() {
+  #ifdef SIM
+  return SimulatorManager::sim.sim_get_adc();
+  #else
   return empty_data();
+  #endif
 }

--- a/CentralComputing/CANManager.cpp
+++ b/CentralComputing/CANManager.cpp
@@ -17,5 +17,9 @@ std::shared_ptr<CANData> CANManager::refresh() {
 }
 
 std::shared_ptr<CANData> CANManager::refresh_sim() {
+  #ifdef SIM
+  return SimulatorManager::sim.sim_get_can();
+  #else
   return empty_data();
+  #endif
 }

--- a/CentralComputing/Defines.hpp
+++ b/CentralComputing/Defines.hpp
@@ -2,6 +2,9 @@
 #define STRUCTS_H_
 
 #include <memory>
+
+class MotionModel;
+
 enum E_States {
   ST_SAFE_MODE,
   ST_FUNCTIONAL_TEST,

--- a/CentralComputing/I2CManager.cpp
+++ b/CentralComputing/I2CManager.cpp
@@ -17,5 +17,10 @@ std::shared_ptr<I2CData> I2CManager::refresh() {
 }
 
 std::shared_ptr<I2CData> I2CManager::refresh_sim() {
+  #ifdef SIM
+  return SimulatorManager::sim.sim_get_i2c();
+  #else
   return empty_data();
+  #endif
 }
+

--- a/CentralComputing/Makefile
+++ b/CentralComputing/Makefile
@@ -16,7 +16,7 @@ CXX_BBB 	:= arm-linux-gnueabihf-g++
 WARNINGS 	:= -Wall -Wextra -pedantic -Wdouble-promotion -Wcast-align -Wcast-qual -Wctor-dtor-privacy -Wdisabled-optimization -Wformat=2 -Winit-self -Wlogical-op -Wmissing-declarations -Wmissing-include-dirs -Wnoexcept -Woverloaded-virtual -Wredundant-decls -Wshadow -Wsign-conversion -Wsign-promo -Wstrict-null-sentinel -Wstrict-overflow=5 -Wswitch-default -Wno-unused
 
 
-INCLUDE_DIRS	:= -IStateMachineCompact -I${GTEST_DIR}/include -I.
+INCLUDE_DIRS	:= -IStateMachineCompact -I${GTEST_DIR}/include -I. -Iscenarios
 CFLAGS_RELEASE 	:= -O2 $(WARNINGS) -g -std=c++11 -c -MMD -MP $(INCLUDE_DIRS) -D_GNU_SOURCE -pthread -DNDEBUG
 CFLAGS_DEBUG   	:= -O0 $(WARNINGS) -g -std=c++11 -c -MMD -MP $(INCLUDE_DIRS) -D_GNU_SOURCE -pthread -DDEBUG 
 CFLAGS_SIM 	:= -O0 $(WARNINGS) -g -std=c++11 -c -MMD -MP $(INCLUDE_DIRS) -D_GNU_SOURCE -pthread -DDEBUG -DSIM 
@@ -88,6 +88,7 @@ mkdir_obj:
 	@mkdir -p $(LIB_DIR)
 	@mkdir -p $(OBJ_DIR)/StateMachineCompact
 	@mkdir -p $(OBJ_DIR)/tests
+	@mkdir -p $(OBJ_DIR)/scenarios
 
 # Compile libgtest
 ${LIB_DIR}/gtest-all.o : ${GTEST_DIR}/src/gtest-all.cc 

--- a/CentralComputing/MotionModel.cpp
+++ b/CentralComputing/MotionModel.cpp
@@ -61,7 +61,7 @@ void MotionModel::calculate(std::shared_ptr<UnifiedState> state) {
 // get MotionData object
 void MotionModel::calculate_sim(std::shared_ptr<UnifiedState> state) {
   #ifdef SIM
-  state->motion_data = SimulatorManager::sim.sim_get_motion();
+  state->motion_data = SimulatorManager::sim.sim_get_motion(this, state);
   #endif
 }
 

--- a/CentralComputing/MotionModel.h
+++ b/CentralComputing/MotionModel.h
@@ -7,6 +7,7 @@
 #include "Configurator.h"
 #include <memory>
 
+// Class pre-defined in Defines.hpp, FYI
 class MotionModel {
  public:
   // Used to read variables in from config file

--- a/CentralComputing/PRUManager.cpp
+++ b/CentralComputing/PRUManager.cpp
@@ -104,5 +104,9 @@ int32_t PRUManager::convert_to_velocity(uint32_t decay, uint32_t delta, uint32_t
 }
 
 std::shared_ptr<PRUData> PRUManager::refresh_sim() {
+  #ifdef SIM
+  return SimulatorManager::sim.sim_get_pru();
+  #else
   return empty_data();
+  #endif
 }

--- a/CentralComputing/Simulator.cpp
+++ b/CentralComputing/Simulator.cpp
@@ -110,9 +110,9 @@ void Simulator::disconnect() {
 }
 
 void Simulator::stop() {
-  std::lock_guard<std::mutex> guard(mutex);
   logging(false);
   disconnect();
+  std::lock_guard<std::mutex> guard(mutex);
   scenario = nullptr;
 }
 
@@ -230,7 +230,6 @@ std::shared_ptr<MotionData> Simulator::sim_get_motion(MotionModel * mm, std::sha
     mm->calculate(state);
     return state->motion_data;
   }
-
 }
 
 #endif

--- a/CentralComputing/Simulator.cpp
+++ b/CentralComputing/Simulator.cpp
@@ -9,6 +9,7 @@ Simulator SimulatorManager::sim;
 Simulator::Simulator() {
   reset_motion();
   connected.reset();
+  scenario = std::nullptr;
 }
 
 int Simulator::start_server(const char * hostname, const char * port) {
@@ -109,6 +110,10 @@ void Simulator::disconnect() {
   close(socketfd);  // close TCP server
 }
 
+void Simulator::set_scenario(std::shared_ptr<Scenario> scn) {
+  scenario = scn;
+}
+
 void Simulator::logging(bool enable) {
   std::lock_guard<std::mutex> guard(mutex);
   enable_logging = enable;
@@ -150,51 +155,25 @@ void Simulator::sim_brake_set_pressure(uint8_t value) {
   pressure = value;
 }
 
+std::shared_ptr<ADCData> Simulator::sim_get_adc() {
+
+}
+
+std::shared_ptr<CANData> Simulator::sim_get_can() {
+
+}
+
+std::shared_ptr<I2CData> Simulator::sim_get_i2c() {
+
+}
+
+std::shared_ptr<PRUData> Simulator::sim_get_pru() {
+
+}
+
 std::shared_ptr<MotionData> Simulator::sim_get_motion() {
   std::lock_guard<std::mutex> guard(mutex);
 
-  // FOR FIRST CALL
-  if (timeLast == -1) {
-    timeDelta = 0.000;
-  } else {  // SUBSEQUENT CALLS
-    timeDelta = Utils::microseconds() - timeLast;
-  }
-
-  if (motorsOn) {
-    acceleration = MAX_ACCEL * throttle;
-  } else if (brakesOn) {
-    acceleration = MAX_DECEL * pressure;
-  } else {
-    acceleration = 0;
-  }
-
-
-  double deltaSeconds = static_cast<double>(timeDelta) / 1000000.0;
-
-  // KINEMATIC PHYSICS CALCULATIONS
-  velocity = lastVelocity + (acceleration * deltaSeconds);
-  position = lastPosition + ((lastVelocity + velocity)/2 * deltaSeconds) 
-              + (0.5 * acceleration * deltaSeconds * deltaSeconds);
-
-  // CREATING A STATESPACE OBJECT AND SETTING ITS ARRAY'S VALUES
-  std::shared_ptr<MotionData> space = std::make_shared<MotionData>();
-  space->x[0] = position;
-  space->x[1] = velocity;
-  space->x[2] = acceleration;
-
-  if (enable_logging) {
-    print(LogLevel::LOG_DEBUG, 
-      "Motion: Pos: %.2f, Vel: %.2f, Acl= %.2f, lastPos= %.2f, lastVel = %.2f, delta = %d, timeLast=%ld, t = %ld\n",
-      position, velocity, acceleration, lastPosition, lastVelocity, timeDelta, timeLast, Utils::microseconds());
-  }
-
-  // UPDATING VARIABLES
-  lastPosition = position;
-  lastVelocity = velocity;
-  timeLast = Utils::microseconds();
-
-
-  return space;
 }
 
 

--- a/CentralComputing/Simulator.h
+++ b/CentralComputing/Simulator.h
@@ -5,9 +5,6 @@
 #include "Defines.hpp"
 #include "Scenario.hpp"
 
-#define MAX_ACCEL 9.81
-#define MAX_DECEL -9.81
-
 class Simulator {
  public:
   Simulator();
@@ -57,6 +54,11 @@ class Simulator {
     */
   void sim_brake_set_pressure(uint8_t value);
 
+  std::shared_ptr<ADCData> sim_get_adc();
+  std::shared_ptr<I2CData> sim_get_i2c();
+  std::shared_ptr<CANData> sim_get_can();
+  std::shared_ptr<PRUData> sim_get_pru();
+
   /*
     * Uses the current state of the brakes/motors to simulate the new position, velocity, 
     * and acceleration and returns them as a MotionData object
@@ -80,9 +82,16 @@ class Simulator {
   void disconnect();
 
   /**
+   * Shutdown the simulator and prepare for the next test cycle
+   * Calls the disconnect() function.
+   * Acts like a destructor
+   */
+  void stop();
+
+  /**
    * Set the Scenario to use 
    */
-  void set_scenario(std::shared_ptr<Scenario> scn);
+  void set_scenario(std::shared_ptr<Scenario> s);
 
   std::atomic<bool> active_connection;
   Event closed;

--- a/CentralComputing/Simulator.h
+++ b/CentralComputing/Simulator.h
@@ -4,22 +4,84 @@
 #include "TCPManager.h"
 #include "Defines.hpp"
 #include "Scenario.hpp"
+#include "MotionModel.h"
+
+/**
+ * This class is designed to be the "glue" between the tests, and the rest of the codebase. There are two parts
+ * 
+ * Network Part:
+ *   Part of this class defines and runs a TCP server that the tests use to send commands to the Pod
+ * 
+ * Hook Part: 
+ *   The other part of this class defines hooks that the codebase calls, such that we can inject
+ *   whatever sensor values we want, based on configurable "Scenarios"
+ */
 
 class Simulator {
  public:
   Simulator();
 
+  //
+  // NETWORK PART
+  //
+
   /**
-   * Connects to the pod server at hostname/port
+   * Set up TCP server at hostname and port. Do not connect yet
    * @param hostname the hostname to connect to
    * @param port the port to connect to
    */
-  void sim_connect();
-  
   int start_server(const char * hostname, const char * port);
 
+  /**
+   * A helper function for sim_connect()
+   */
   int accept_client();
 
+  /**
+   * Allows connection from a client. Spawns Read and Write threads
+   */
+  void sim_connect();
+  
+  /**
+   * Sends the given command to the client (the connected pod)
+   * @param command the command to send
+   */
+  bool send_command(std::shared_ptr<TCPManager::Network_Command> command);
+
+  /**
+   * Thread function, reads continually and updates the internal simulate state variables
+   */
+  void read_loop();
+
+  /**
+   * Close the active connection and free any owned variables
+   */
+  void disconnect();
+
+  /**
+   * Shutdown the simulator and prepare for the next test cycle
+   * Calls the disconnect() function.
+   * Acts like a destructor
+   */
+  void stop();
+
+  //
+  // HOOK PART
+  //
+  // NOTE: Either the ADC/I2C/CAN/PRU functions are called, or the sim_get_motion() is called
+  // Motion is normally derived from the ADC/I2C/CAN/PRU values, so we could calculate it that way.
+  // Or we can simply inject arbitary motion values using sim_get_motion()
+  //
+  // The set motor / set brake functions are not affected by the above motion model calculations
+
+  /**
+   * Set the Scenario to use 
+   */
+  void set_scenario(std::shared_ptr<Scenario> s);
+  
+  /**
+   * Enables or disables logging in the simulator (printing of motion data)
+   */
   void logging(bool enable);
 
   /*
@@ -54,44 +116,33 @@ class Simulator {
     */
   void sim_brake_set_pressure(uint8_t value);
 
+  /*
+    * Simulates ADC data, gets it from scenario
+    */
   std::shared_ptr<ADCData> sim_get_adc();
+
+  /*
+    * Simulates I2C data, gets it from scenario
+    */
   std::shared_ptr<I2CData> sim_get_i2c();
+
+  /*
+    * Simulates CAN data, gets it from scenario
+    */
   std::shared_ptr<CANData> sim_get_can();
+
+  /*
+    * Simulates PRU data, gets it from scenario
+    */
   std::shared_ptr<PRUData> sim_get_pru();
 
   /*
-    * Uses the current state of the brakes/motors to simulate the new position, velocity, 
-    * and acceleration and returns them as a MotionData object
+    * Simulates Motion data, gets it from scenario
+    * Either this is called, OR the ADC/I2C/CAN/PRU functions are called.
+    * Motion is normally derived from the ADC/I2C/CAN/PRU values, so we could calculate it that way.
+    * Or we can simply inject arbitary motion values (using the scenario)
     */
-  std::shared_ptr<MotionData> sim_get_motion();
-
-  /**
-   * Sends the given command to the connected pod
-   * @param command the command to send
-   */
-  bool send_command(std::shared_ptr<TCPManager::Network_Command> command);
-
-  /**
-   * Thread function, reads continually and updates the internal simulate state variables
-   */
-  void read_loop();
-
-  /**
-   * Close the active connection and free any owned variables
-   */
-  void disconnect();
-
-  /**
-   * Shutdown the simulator and prepare for the next test cycle
-   * Calls the disconnect() function.
-   * Acts like a destructor
-   */
-  void stop();
-
-  /**
-   * Set the Scenario to use 
-   */
-  void set_scenario(std::shared_ptr<Scenario> s);
+  std::shared_ptr<MotionData> sim_get_motion(MotionModel * mm, std::shared_ptr<UnifiedState> state);
 
   std::atomic<bool> active_connection;
   Event closed;
@@ -103,10 +154,10 @@ class Simulator {
   int clientfd;
 
   std::shared_ptr<Scenario> scenario;
-
 };
+
 namespace SimulatorManager {
   extern Simulator sim;
-}
+}  // namespace SimulatorManager
 
 #endif  // SIMULATOR_H_

--- a/CentralComputing/Simulator.h
+++ b/CentralComputing/Simulator.h
@@ -3,6 +3,7 @@
 
 #include "TCPManager.h"
 #include "Defines.hpp"
+#include "Scenario.hpp"
 
 #define MAX_ACCEL 9.81
 #define MAX_DECEL -9.81
@@ -29,12 +30,10 @@ class Simulator {
     */
   void sim_motor_enable();
 
-
   /*
     * Simulates disarming the motor
     */
   void sim_motor_disable();
-
 
   /*
     * Simulates setting the motor throttle to a specific value
@@ -42,18 +41,15 @@ class Simulator {
     */
   void sim_motor_set_throttle(uint8_t value);
 
-
   /*
     * Simulates enabling the brakes
     */
   void sim_brake_enable();
 
-
   /*
     * Simulates disabling the brakes
     */
   void sim_brake_disable();
-
 
   /*
     * Simulates setting the brake pressure to a specific Value
@@ -61,13 +57,11 @@ class Simulator {
     */
   void sim_brake_set_pressure(uint8_t value);
 
-
   /*
     * Uses the current state of the brakes/motors to simulate the new position, velocity, 
     * and acceleration and returns them as a MotionData object
     */
   std::shared_ptr<MotionData> sim_get_motion();
-
 
   /**
    * Sends the given command to the connected pod
@@ -75,12 +69,10 @@ class Simulator {
    */
   bool send_command(std::shared_ptr<TCPManager::Network_Command> command);
 
-
   /**
    * Thread function, reads continually and updates the internal simulate state variables
    */
   void read_loop();
-
 
   /**
    * Close the active connection and free any owned variables
@@ -88,9 +80,9 @@ class Simulator {
   void disconnect();
 
   /**
-   * Resets the motion variables
+   * Set the Scenario to use 
    */
-  void reset_motion();
+  void set_scenario(std::shared_ptr<Scenario> scn);
 
   std::atomic<bool> active_connection;
   Event closed;
@@ -98,22 +90,11 @@ class Simulator {
   std::thread read_thread;
   std::mutex mutex;  // To get rid of data races when accessing motion data
 
-  bool enable_logging = true;
-
   int socketfd;
   int clientfd;
 
-  int64_t timeLast = -1;
-  int64_t timeDelta = 0.000;
-  bool motorsOn = false;
-  bool brakesOn = false;
-  uint8_t throttle = 0.000;
-  uint8_t pressure = 0.000;
-  double position = 0.000;
-  double lastPosition = 0.000;
-  double velocity = 0.000;
-  double lastVelocity = 0.000;
-  double acceleration = 0.000;
+  std::shared_ptr<Scenario> scenario;
+
 };
 namespace SimulatorManager {
   extern Simulator sim;

--- a/CentralComputing/SourceManagerBase.hpp
+++ b/CentralComputing/SourceManagerBase.hpp
@@ -10,14 +10,6 @@
 #include <mutex>  // NOLINT
 #include <atomic>
 
-#ifdef SIM
-#include <fstream>
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wctor-dtor-privacy"
-#include "gtest/gtest.h"
-#pragma GCC diagnostic pop
-#endif
-
 using Utils::print;
 using Utils::LogLevel;
 

--- a/CentralComputing/SourceManagerBase.hpp
+++ b/CentralComputing/SourceManagerBase.hpp
@@ -105,7 +105,6 @@ class SourceManagerBase {
     }
   }
 
- protected:
   std::shared_ptr<Data> empty_data() {
     std::shared_ptr<Data> d = std::make_shared<Data>();
     memset(d.get(), (uint8_t)0, sizeof(Data));

--- a/CentralComputing/defaultConfig.txt
+++ b/CentralComputing/defaultConfig.txt
@@ -1,8 +1,8 @@
-tmp_manager_timeout 1000000.0
-i2c_manager_timeout 1000000.0
-can_manager_timeout 1000000.0
-adc_manager_timeout 1000000.0
-pru_manager_timeout 1000000.0
+tmp_manager_timeout 100000.0
+i2c_manager_timeout 100000.0
+can_manager_timeout 100000.0
+adc_manager_timeout 100000.0
+pru_manager_timeout 100000.0
 logic_loop_timeout  1000.0
 
 tcp_port 8001

--- a/CentralComputing/scenarios/Scenario.hpp
+++ b/CentralComputing/scenarios/Scenario.hpp
@@ -1,6 +1,5 @@
 #include "Defines.hpp"
 #include "Utils.h"
-#include "SourceManager.h"
 
 using Utils::print;
 using Utils::LogLevel;
@@ -14,23 +13,30 @@ class Scenario{
 
   // By default, all functions return "empty data"
   std::shared_ptr<ADCData> sim_get_adc() {
-    return SourceManager::ADC.empty_data();
+    std::shared_ptr<ADCData> d = std::make_shared<ADCData>();
+    memset(d.get(), (uint8_t)0, sizeof(ADCData));
+    return d;
   }
   std::shared_ptr<CANData> sim_get_can() {
-    return SourceManager::CAN.empty_data();
+    std::shared_ptr<CANData> d = std::make_shared<CANData>();
+    memset(d.get(), (uint8_t)0, sizeof(CANData));
+    return d;
   }
   std::shared_ptr<I2CData> sim_get_i2c() {
-    return SourceManager::I2C.empty_data();
+    std::shared_ptr<I2CData> d = std::make_shared<I2CData>();
+    memset(d.get(), (uint8_t)0, sizeof(I2CData));
+    return d;
   }
   std::shared_ptr<PRUData> sim_get_pru() {
-    return SourceManager::PRU.empty_data();
+    std::shared_ptr<PRUData> d = std::make_shared<PRUData>();
+    memset(d.get(), (uint8_t)0, sizeof(PRUData));
+    return d;
   }
   virtual std::shared_ptr<MotionData> sim_get_motion() {
     std::shared_ptr<MotionData> space = std::make_shared<MotionData>();
     space->x[0] = 0;
     space->x[1] = 0;
     space->x[2] = 0;
-
     return space;
   }
 

--- a/CentralComputing/scenarios/Scenario.hpp
+++ b/CentralComputing/scenarios/Scenario.hpp
@@ -1,0 +1,78 @@
+#include "Defines.hpp"
+#include "Utils.h"
+#include "SourceManager.h"
+
+using Utils::print;
+using Utils::LogLevel;
+
+// Abstract class 
+class Scenario{
+ public:
+  
+  // User must extend this class to implement this function
+  virtual bool use_motion_model() = 0;
+
+  // By default, all functions return "empty data"
+  std::shared_ptr<ADCData> sim_get_adc() {
+    return SourceManager::ADC.empty_data();
+  }
+  std::shared_ptr<CANData> sim_get_can() {
+    return SourceManager::CAN.empty_data();
+  }
+  std::shared_ptr<I2CData> sim_get_i2c() {
+    return SourceManager::I2C.empty_data();
+  }
+  std::shared_ptr<PRUData> sim_get_pru() {
+    return SourceManager::PRU.empty_data();
+  }
+  virtual std::shared_ptr<MotionData> sim_get_motion() {
+    std::shared_ptr<MotionData> space = std::make_shared<MotionData>();
+    space->x[0] = 0;
+    space->x[1] = 0;
+    space->x[2] = 0;
+
+    return space;
+  }
+
+  void logging(bool enable) {
+    enable_logging = enable;
+  }
+
+  void sim_motor_enable() {
+    motorsOn = true;
+  }
+  
+  void sim_motor_disable() {
+    motorsOn = false;
+  }
+  
+  void sim_motor_set_throttle(uint8_t value) {
+    throttle = value;
+  }
+  
+  void sim_brake_enable() {
+    brakesOn = true;
+  }
+  
+  void sim_brake_disable() {
+    brakesOn = false;
+  }
+  
+  void sim_brake_set_pressure(uint8_t value) {
+    pressure = value;
+  }
+
+  bool enable_logging = true;
+  int64_t timeLast = -1;
+  int64_t timeDelta = 0.000;
+  bool motorsOn = false;
+  bool brakesOn = false;
+  uint8_t throttle = 0.000;
+  uint8_t pressure = 0.000;
+  double position = 0.000;
+  double lastPosition = 0.000;
+  double velocity = 0.000;
+  double lastVelocity = 0.000;
+  double acceleration = 0.000;
+
+};

--- a/CentralComputing/scenarios/Scenario.hpp
+++ b/CentralComputing/scenarios/Scenario.hpp
@@ -4,6 +4,7 @@
 #include "Utils.h"
 
 using Utils::print;
+using Utils::microseconds;
 using Utils::LogLevel;
 
 // Abstract class 
@@ -52,6 +53,7 @@ class Scenario{
 
   void sim_motor_enable() {
     motorsOn = true;
+    motors_on = microseconds();
   }
   
   void sim_motor_disable() {
@@ -86,6 +88,7 @@ class Scenario{
   double velocity = 0.000;
   double lastVelocity = 0.000;
   double acceleration = 0.000;
+  int64_t motors_on = 0;
 
 };
 #endif 

--- a/CentralComputing/scenarios/Scenario.hpp
+++ b/CentralComputing/scenarios/Scenario.hpp
@@ -14,26 +14,30 @@ class Scenario{
   virtual bool use_motion_model() = 0;
 
   // By default, all functions return "empty data"
-  std::shared_ptr<ADCData> sim_get_adc() {
+  virtual std::shared_ptr<ADCData> sim_get_adc() {
     std::shared_ptr<ADCData> d = std::make_shared<ADCData>();
     memset(d.get(), (uint8_t)0, sizeof(ADCData));
     return d;
   }
-  std::shared_ptr<CANData> sim_get_can() {
+  
+  virtual std::shared_ptr<CANData> sim_get_can() {
     std::shared_ptr<CANData> d = std::make_shared<CANData>();
     memset(d.get(), (uint8_t)0, sizeof(CANData));
     return d;
   }
-  std::shared_ptr<I2CData> sim_get_i2c() {
+
+  virtual std::shared_ptr<I2CData> sim_get_i2c() {
     std::shared_ptr<I2CData> d = std::make_shared<I2CData>();
     memset(d.get(), (uint8_t)0, sizeof(I2CData));
     return d;
   }
-  std::shared_ptr<PRUData> sim_get_pru() {
+
+  virtual std::shared_ptr<PRUData> sim_get_pru() {
     std::shared_ptr<PRUData> d = std::make_shared<PRUData>();
     memset(d.get(), (uint8_t)0, sizeof(PRUData));
     return d;
   }
+
   virtual std::shared_ptr<MotionData> sim_get_motion() {
     std::shared_ptr<MotionData> space = std::make_shared<MotionData>();
     space->x[0] = 0;

--- a/CentralComputing/scenarios/Scenario.hpp
+++ b/CentralComputing/scenarios/Scenario.hpp
@@ -1,3 +1,5 @@
+#ifndef SCENARIO_H_
+#define SCENARIO_H_
 #include "Defines.hpp"
 #include "Utils.h"
 
@@ -82,3 +84,4 @@ class Scenario{
   double acceleration = 0.000;
 
 };
+#endif 

--- a/CentralComputing/scenarios/ScenarioBasic.cpp
+++ b/CentralComputing/scenarios/ScenarioBasic.cpp
@@ -1,4 +1,8 @@
+#ifdef SIM
 #include "ScenarioBasic.h"
+
+#define MAX_ACCEL 9.81
+#define MAX_DECEL -9.81
 
 bool ScenarioBasic::use_motion_model() {
   return true;
@@ -47,3 +51,4 @@ std::shared_ptr<MotionData> ScenarioBasic::sim_get_motion() {
 
   return space;
 }
+#endif

--- a/CentralComputing/scenarios/ScenarioBasic.cpp
+++ b/CentralComputing/scenarios/ScenarioBasic.cpp
@@ -1,0 +1,49 @@
+#include "ScenarioBasic.h"
+
+bool ScenarioBasic::use_motion_model() {
+  return true;
+}
+std::shared_ptr<MotionData> sim_get_motion() {
+  // FOR FIRST CALL
+  if (timeLast == -1) {
+    timeDelta = 0.000;
+  } else {  // SUBSEQUENT CALLS
+    timeDelta = Utils::microseconds() - timeLast;
+  }
+
+  if (motorsOn) {
+    acceleration = MAX_ACCEL * throttle;
+  } else if (brakesOn) {
+    acceleration = MAX_DECEL * pressure;
+  } else {
+    acceleration = 0;
+  }
+
+
+  double deltaSeconds = static_cast<double>(timeDelta) / 1000000.0;
+
+  // KINEMATIC PHYSICS CALCULATIONS
+  velocity = lastVelocity + (acceleration * deltaSeconds);
+  position = lastPosition + ((lastVelocity + velocity)/2 * deltaSeconds) 
+              + (0.5 * acceleration * deltaSeconds * deltaSeconds);
+
+  // CREATING A STATESPACE OBJECT AND SETTING ITS ARRAY'S VALUES
+  std::shared_ptr<MotionData> space = std::make_shared<MotionData>();
+  space->x[0] = position;
+  space->x[1] = velocity;
+  space->x[2] = acceleration;
+
+  if (enable_logging) {
+    print(LogLevel::LOG_DEBUG, 
+      "Motion: Pos: %.2f, Vel: %.2f, Acl= %.2f, lastPos= %.2f, lastVel = %.2f, delta = %d, timeLast=%ld, t = %ld\n",
+      position, velocity, acceleration, lastPosition, lastVelocity, timeDelta, timeLast, Utils::microseconds());
+  }
+
+  // UPDATING VARIABLES
+  lastPosition = position;
+  lastVelocity = velocity;
+  timeLast = Utils::microseconds();
+
+
+  return space;
+}

--- a/CentralComputing/scenarios/ScenarioBasic.cpp
+++ b/CentralComputing/scenarios/ScenarioBasic.cpp
@@ -3,7 +3,8 @@
 bool ScenarioBasic::use_motion_model() {
   return true;
 }
-std::shared_ptr<MotionData> sim_get_motion() {
+
+std::shared_ptr<MotionData> ScenarioBasic::sim_get_motion() {
   // FOR FIRST CALL
   if (timeLast == -1) {
     timeDelta = 0.000;
@@ -43,7 +44,6 @@ std::shared_ptr<MotionData> sim_get_motion() {
   lastPosition = position;
   lastVelocity = velocity;
   timeLast = Utils::microseconds();
-
 
   return space;
 }

--- a/CentralComputing/scenarios/ScenarioBasic.h
+++ b/CentralComputing/scenarios/ScenarioBasic.h
@@ -1,5 +1,8 @@
 #include "Scenario.hpp"
 
+#define MAX_ACCEL 9.81
+#define MAX_DECEL -9.81
+
 class ScenarioBasic : public Scenario {
  public:
 

--- a/CentralComputing/scenarios/ScenarioBasic.h
+++ b/CentralComputing/scenarios/ScenarioBasic.h
@@ -1,7 +1,6 @@
+#ifndef SCENARIOBASIC_H_
+#define SCENARIOBASIC_H_
 #include "Scenario.hpp"
-
-#define MAX_ACCEL 9.81
-#define MAX_DECEL -9.81
 
 class ScenarioBasic : public Scenario {
  public:
@@ -9,3 +8,4 @@ class ScenarioBasic : public Scenario {
   bool use_motion_model();
   std::shared_ptr<MotionData> sim_get_motion();
 };
+#endif

--- a/CentralComputing/scenarios/ScenarioBasic.h
+++ b/CentralComputing/scenarios/ScenarioBasic.h
@@ -1,0 +1,8 @@
+#include "Scenario.hpp"
+
+class ScenarioBasic : public Scenario {
+ public:
+
+  bool use_motion_model();
+  std::shared_ptr<MotionData> sim_get_motion();
+};

--- a/CentralComputing/scenarios/ScenarioRealLong.cpp
+++ b/CentralComputing/scenarios/ScenarioRealLong.cpp
@@ -1,0 +1,77 @@
+#ifdef SIM
+#include "ScenarioRealLong.h"
+#include "Utils.h"
+using Utils::microseconds;
+using Utils::clamp;
+
+ScenarioRealLong::ScenarioRealLong() {
+  pru_delta_seconds = microseconds();
+  can_delta_seconds = pru_delta_seconds;
+}
+
+void ScenarioRealLong::true_motion() {
+  timeDelta = Utils::microseconds() - timeLast;
+  double deltaSeconds = static_cast<double>(timeDelta) / 1000000.0;
+
+  if (motorsOn) {
+    acceleration = 9 - 2.5 * clamp((microseconds() - motors_on)/10000000.0, 0.0, 1.0);
+  } else if (brakesOn) {
+    acceleration = -20;
+  } else {
+    acceleration = 0;
+  }
+
+  velocity = lastVelocity + (acceleration * deltaSeconds);
+  position = lastPosition + ((lastVelocity + velocity)/2 * deltaSeconds) 
+              + (0.5 * acceleration * deltaSeconds * deltaSeconds);
+  lastPosition = position;
+  lastVelocity = velocity;
+
+  timeLast = Utils::microseconds();
+}
+
+bool ScenarioRealLong::use_motion_model() {
+  return false;
+}
+
+std::shared_ptr<ADCData> ScenarioRealLong::sim_get_adc() {
+  true_motion();
+  std::shared_ptr<ADCData> d = std::make_shared<ADCData>();
+  d->accel[0] =  acceleration;
+  d->accel[1] =  acceleration;
+  d->accel[2] =  acceleration;
+  return d;
+}
+
+std::shared_ptr<CANData> ScenarioRealLong::sim_get_can() {
+  true_motion();
+  std::shared_ptr<CANData> d = std::make_shared<CANData>();
+  memset(d.get(), (uint8_t)0, sizeof(CANData));
+  return d;
+}
+
+std::shared_ptr<I2CData> ScenarioRealLong::sim_get_i2c() {
+  true_motion();
+  std::shared_ptr<I2CData> d = std::make_shared<I2CData>();
+  memset(d.get(), (uint8_t)0, sizeof(I2CData));
+  return d;
+}
+
+std::shared_ptr<PRUData> ScenarioRealLong::sim_get_pru() {
+  true_motion();
+  print(LogLevel::LOG_DEBUG, 
+    "Motion: Pos: %.2f, Vel: %.2f, Acl: %.2f \n", position, velocity, acceleration );
+
+  std::shared_ptr<PRUData> d = std::make_shared<PRUData>();
+  d->wheel_velocity[0] =  velocity;
+  d->wheel_velocity[1] =  velocity;
+
+  d->orange_distance[0] =  position;
+  d->orange_distance[1] =  d->orange_distance[0];
+  d->wheel_distance[0] =  d->orange_distance[0];
+  d->wheel_distance[1] =  d->orange_distance[0];
+
+  return d;
+}
+
+#endif

--- a/CentralComputing/scenarios/ScenarioRealLong.h
+++ b/CentralComputing/scenarios/ScenarioRealLong.h
@@ -1,0 +1,18 @@
+#ifndef SCENARIOREALNOFAULT2_H_
+#define SCENARIOREALNOFAULT2_H_
+#include "Scenario.hpp"
+
+class ScenarioRealLong : public Scenario {
+ public:
+  ScenarioRealLong();
+
+  bool use_motion_model();
+  std::shared_ptr<ADCData> sim_get_adc();
+  std::shared_ptr<CANData> sim_get_can();
+  std::shared_ptr<I2CData> sim_get_i2c();
+  std::shared_ptr<PRUData> sim_get_pru();
+
+  void true_motion();
+  int64_t pru_delta_seconds, can_delta_seconds;
+};
+#endif

--- a/CentralComputing/scenarios/ScenarioRealNoFault.cpp
+++ b/CentralComputing/scenarios/ScenarioRealNoFault.cpp
@@ -1,0 +1,71 @@
+#ifdef SIM
+#include "ScenarioRealNoFault.h"
+#include "Utils.h"
+using Utils::microseconds;
+
+#define MAX_ACCEL 9.81
+#define MAX_DECEL -9.81
+
+ScenarioRealNoFault::ScenarioRealNoFault(){
+  pru_delta_seconds = microseconds();
+  can_delta_seconds = pru_delta_seconds;
+}
+
+bool ScenarioRealNoFault::use_motion_model() {
+  return false;
+}
+
+std::shared_ptr<ADCData> ScenarioRealNoFault::sim_get_adc() {
+  std::shared_ptr<ADCData> d = std::make_shared<ADCData>();
+  if (motorsOn) {
+    d->accel[0] =  MAX_ACCEL * throttle;
+    d->accel[1] =  MAX_ACCEL * throttle;
+    d->accel[2] =  MAX_ACCEL * throttle;
+    acceleration = MAX_ACCEL * throttle;
+  } else if (brakesOn) {
+    d->accel[0] =  MAX_ACCEL * pressure;
+    d->accel[1] =  MAX_ACCEL * pressure;
+    d->accel[2] =  MAX_ACCEL * pressure;
+    acceleration = MAX_ACCEL * pressure;
+  } else {
+    d->accel[0] =  0;
+    d->accel[1] =  0;
+    d->accel[2] =  0;
+    acceleration = 0;
+  }
+  return d;
+}
+
+std::shared_ptr<CANData> ScenarioRealNoFault::sim_get_can() {
+  std::shared_ptr<CANData> d = std::make_shared<CANData>();
+  memset(d.get(), (uint8_t)0, sizeof(CANData));
+  return d;
+}
+std::shared_ptr<I2CData> ScenarioRealNoFault::sim_get_i2c() {
+  std::shared_ptr<I2CData> d = std::make_shared<I2CData>();
+  memset(d.get(), (uint8_t)0, sizeof(I2CData));
+  return d;
+}
+std::shared_ptr<PRUData> ScenarioRealNoFault::sim_get_pru() {
+  std::shared_ptr<PRUData> d = std::make_shared<PRUData>();
+  int64_t td = microseconds() - pru_delta_seconds;
+
+  double deltaSeconds = static_cast<double>(td) / 1000000.0;
+
+  d->wheel_velocity[0] =  lastVelocity + (acceleration * deltaSeconds);
+  d->wheel_velocity[1] =  d->wheel_velocity[0];
+  velocity =  d->wheel_velocity[0];
+
+  d->orange_distance[0] =  lastPosition + ((lastVelocity + velocity)/2 * deltaSeconds) 
+              + (0.5 * acceleration * deltaSeconds * deltaSeconds);
+  d->orange_distance[1] =  d->orange_distance[0];
+  d->wheel_distance[0] =  d->orange_distance[0];
+  d->wheel_distance[1] =  d->orange_distance[0];
+
+  lastPosition = position;
+  lastVelocity = velocity;
+  pru_delta_seconds = microseconds();
+  return d;
+}
+
+#endif

--- a/CentralComputing/scenarios/ScenarioRealNoFault.h
+++ b/CentralComputing/scenarios/ScenarioRealNoFault.h
@@ -1,0 +1,16 @@
+#ifndef SCENARIOREALNOFAULT_H_
+#define SCENARIOREALNOFAULT_H_
+#include "Scenario.hpp"
+
+class ScenarioRealNoFault : public Scenario {
+ public:
+  ScenarioRealNoFault();
+
+  bool use_motion_model();
+  std::shared_ptr<ADCData> sim_get_adc();
+  std::shared_ptr<CANData> sim_get_can();
+  std::shared_ptr<I2CData> sim_get_i2c();
+  std::shared_ptr<PRUData> sim_get_pru();
+  int64_t pru_delta_seconds, can_delta_seconds;
+};
+#endif

--- a/CentralComputing/tests/AutoTests.cpp
+++ b/CentralComputing/tests/AutoTests.cpp
@@ -1,6 +1,7 @@
 #ifdef SIM // Only compile if building test executable
 #include "PodTest.cpp"
 #include "ScenarioBasic.h"
+#include "ScenarioRealNoFault.h"
 using std::make_shared;
 
 TEST_F(PodTest, AutomaticTransitionBasic) {
@@ -34,7 +35,7 @@ TEST_F(PodTest, AutomaticTransitionBasic) {
 }
 
 TEST_F(PodTest, AutomaticTransitionSensors) {
-  SimulatorManager::sim.set_scenario(make_shared<ScenarioBasic>());
+  SimulatorManager::sim.set_scenario(make_shared<ScenarioRealNoFault>());
   MoveState(TCPManager::Network_Command_ID::TRANS_FUNCTIONAL_TEST, E_States::ST_FUNCTIONAL_TEST, true);
   MoveState(TCPManager::Network_Command_ID::TRANS_LOADING, E_States::ST_LOADING, true);
   MoveState(TCPManager::Network_Command_ID::TRANS_LAUNCH_READY, E_States::ST_LAUNCH_READY, true);

--- a/CentralComputing/tests/AutoTests.cpp
+++ b/CentralComputing/tests/AutoTests.cpp
@@ -1,7 +1,40 @@
 #ifdef SIM // Only compile if building test executable
 #include "PodTest.cpp"
+#include "ScenarioBasic.h"
+using std::make_shared;
 
 TEST_F(PodTest, AutomaticTransitionBasic) {
+  SimulatorManager::sim.set_scenario(make_shared<ScenarioBasic>());
+  MoveState(TCPManager::Network_Command_ID::TRANS_FUNCTIONAL_TEST, E_States::ST_FUNCTIONAL_TEST, true);
+  MoveState(TCPManager::Network_Command_ID::TRANS_LOADING, E_States::ST_LOADING, true);
+  MoveState(TCPManager::Network_Command_ID::TRANS_LAUNCH_READY, E_States::ST_LAUNCH_READY, true);
+  MoveState(TCPManager::Network_Command_ID::LAUNCH, E_States::ST_FLIGHT_ACCEL, true);
+  EXPECT_TRUE(pod->state_machine->motor.is_enabled());
+
+  pod->processing_command.reset();
+  pod->state_machine->auto_transition_coast.wait();
+  pod->processing_command.wait();
+
+  // There is a EDGE CASE where in the time since we entered Launch/acceleration, that we have already transitioned through coast and into brake
+  // such that the following line failes.
+  // Then when pod->process_command.wait() happens, it waits forever since that command will never happen.
+  // Thus why we have this weird if statement here.
+  if(pod->state_machine->get_current_state() == E_States::ST_FLIGHT_BRAKE){
+    EXPECT_EQ(pod->state_machine->get_current_state(), E_States::ST_FLIGHT_BRAKE);
+    return;
+  }
+  EXPECT_EQ(pod->state_machine->get_current_state(), E_States::ST_FLIGHT_COAST);
+
+
+  pod->processing_command.reset();
+  pod->state_machine->auto_transition_brake.wait();
+  pod->processing_command.wait();
+  EXPECT_EQ(pod->state_machine->get_current_state(), E_States::ST_FLIGHT_BRAKE);
+
+}
+
+TEST_F(PodTest, AutomaticTransitionSensors) {
+  SimulatorManager::sim.set_scenario(make_shared<ScenarioBasic>());
   MoveState(TCPManager::Network_Command_ID::TRANS_FUNCTIONAL_TEST, E_States::ST_FUNCTIONAL_TEST, true);
   MoveState(TCPManager::Network_Command_ID::TRANS_LOADING, E_States::ST_LOADING, true);
   MoveState(TCPManager::Network_Command_ID::TRANS_LAUNCH_READY, E_States::ST_LAUNCH_READY, true);

--- a/CentralComputing/tests/AutoTests.cpp
+++ b/CentralComputing/tests/AutoTests.cpp
@@ -2,6 +2,7 @@
 #include "PodTest.cpp"
 #include "ScenarioBasic.h"
 #include "ScenarioRealNoFault.h"
+#include "ScenarioRealLong.h"
 using std::make_shared;
 
 TEST_F(PodTest, AutomaticTransitionBasic) {
@@ -36,6 +37,36 @@ TEST_F(PodTest, AutomaticTransitionBasic) {
 
 TEST_F(PodTest, AutomaticTransitionSensors) {
   SimulatorManager::sim.set_scenario(make_shared<ScenarioRealNoFault>());
+  MoveState(TCPManager::Network_Command_ID::TRANS_FUNCTIONAL_TEST, E_States::ST_FUNCTIONAL_TEST, true);
+  MoveState(TCPManager::Network_Command_ID::TRANS_LOADING, E_States::ST_LOADING, true);
+  MoveState(TCPManager::Network_Command_ID::TRANS_LAUNCH_READY, E_States::ST_LAUNCH_READY, true);
+  MoveState(TCPManager::Network_Command_ID::LAUNCH, E_States::ST_FLIGHT_ACCEL, true);
+  EXPECT_TRUE(pod->state_machine->motor.is_enabled());
+
+  pod->processing_command.reset();
+  pod->state_machine->auto_transition_coast.wait();
+  pod->processing_command.wait();
+
+  // There is a EDGE CASE where in the time since we entered Launch/acceleration, that we have already transitioned through coast and into brake
+  // such that the following line failes.
+  // Then when pod->process_command.wait() happens, it waits forever since that command will never happen.
+  // Thus why we have this weird if statement here.
+  if(pod->state_machine->get_current_state() == E_States::ST_FLIGHT_BRAKE){
+    EXPECT_EQ(pod->state_machine->get_current_state(), E_States::ST_FLIGHT_BRAKE);
+    return;
+  }
+  EXPECT_EQ(pod->state_machine->get_current_state(), E_States::ST_FLIGHT_COAST);
+
+
+  pod->processing_command.reset();
+  pod->state_machine->auto_transition_brake.wait();
+  pod->processing_command.wait();
+  EXPECT_EQ(pod->state_machine->get_current_state(), E_States::ST_FLIGHT_BRAKE);
+
+}
+
+TEST_F(PodTest, AutomaticTransitionLong) {
+  SimulatorManager::sim.set_scenario(make_shared<ScenarioRealLong>());
   MoveState(TCPManager::Network_Command_ID::TRANS_FUNCTIONAL_TEST, E_States::ST_FUNCTIONAL_TEST, true);
   MoveState(TCPManager::Network_Command_ID::TRANS_LOADING, E_States::ST_LOADING, true);
   MoveState(TCPManager::Network_Command_ID::TRANS_LAUNCH_READY, E_States::ST_LAUNCH_READY, true);

--- a/CentralComputing/tests/PodTest.cpp
+++ b/CentralComputing/tests/PodTest.cpp
@@ -12,12 +12,6 @@ class PodTest : public ::testing::Test
     TCPManager::connected.reset();
     UDPManager::setup.reset();
 
-    // Reset simulator motion
-    SimulatorManager::sim.reset_motion();
-    
-    // Enable logging
-    SimulatorManager::sim.logging(true);
-
     // Startup our server
     EXPECT_TRUE(SimulatorManager::sim.start_server("127.0.0.1", "8001") >= 0);
 
@@ -48,8 +42,7 @@ class PodTest : public ::testing::Test
 
   virtual void TearDown() {
     print(LogLevel::LOG_DEBUG, "Test finished, begin teardown\n");
-    SimulatorManager::sim.logging(false);
-    SimulatorManager::sim.disconnect();
+    SimulatorManager::sim.stop();
     sim_thread.join();
     pod->trigger_shutdown();
     pod_thread.join();


### PR DESCRIPTION
Implemented a "Scenario" system where we should be able to setup many different tests, testing the outputs of all of the sensors.

For example, we can now reasonably setup a test that acts "normally" for the first 10 seconds of the run, and then an ADC sensor drops out. This would have been very difficult to do with the old setup, let alone setup a variety of other different scenarios. 

All a test needs to do is to call `set_scenario()` with the appropriate scenario they would like to use, and the rest is taken care of.

Creating scenarios should be easy to do, if only monotonous. However, thanks to the power of inheritance and virtual functions, we should be able to define common routines. For example we would only have to define how the CAN bus operates (maybe introducing a fault), where we have extended from another class that defines how the rest of the sensors operate. 


Still needs a lot of work to create all of the different scenarios, but this should be a good starting place.