### PR TITLE
Pod4 config automatic state transitions

### DIFF
--- a/CentralComputing/Configurator.cpp
+++ b/CentralComputing/Configurator.cpp
@@ -19,6 +19,7 @@ void Configurator::loadValues() {
   while (inFile >> varName) {
     inFile >> val;
     mapVals.insert(pair<string, string> (varName, val));
+    inFile.ignore(200, '\n');
   }
 }
 

--- a/CentralComputing/Pod_State.cpp
+++ b/CentralComputing/Pod_State.cpp
@@ -30,6 +30,18 @@ Pod_State::Pod_State()
   steady_state_map[ST_FLIGHT_COAST] = &Pod_State::steady_flight_coast;
   steady_state_map[ST_FLIGHT_BRAKE] = &Pod_State::steady_flight_brake;
   steady_state_map[ST_ERROR] = &Pod_State::steady_abort_state;
+
+  if (!(ConfiguratorManager::config.getValue("acceleration_timeout", acceleration_timeout) && 
+      ConfiguratorManager::config.getValue("coast_timeout", coast_timeout) &&
+      ConfiguratorManager::config.getValue("brake_timeout", brake_timeout) &&
+      ConfiguratorManager::config.getValue("estimated_brake_deceleration", estimated_brake_deceleration) &&
+      ConfiguratorManager::config.getValue("length_of_track", length_of_track) &&
+      ConfiguratorManager::config.getValue("brake_buffer_length", brake_buffer_length) &&
+      ConfiguratorManager::config.getValue("not_moving_velocity", not_moving_velocity) &&
+      ConfiguratorManager::config.getValue("not_moving_acceleration", not_moving_acceleration))) {
+    print(LogLevel::LOG_ERROR, "CONFIG FILE ERROR: POD_STATE: Missing necessary configuration\n");
+    exit(1);
+  }
 }
 
 // returns the current state as a E_States enum

--- a/CentralComputing/Pod_State.cpp
+++ b/CentralComputing/Pod_State.cpp
@@ -4,12 +4,6 @@
 using Utils::print;
 using Utils::LogLevel;
 
-double MAX_DECCEL = -19.6;
-double IDEAL_DECCEL = -9.8;
-double LENGTH_OF_TRACK = 1000;
-double BUFFER_LENGTH = 20;
-double MAX_VELOCITY = 550;
-
 Pod_State::Pod_State()
   : StateMachine(ST_MAX_STATES),
   motor(), brakes() {
@@ -21,7 +15,7 @@ Pod_State::Pod_State()
   transition_map[Command::TRANS_FLIGHT_COAST] = &Pod_State::coast;
   transition_map[Command::TRANS_FLIGHT_BRAKE] = &Pod_State::brake;
   transition_map[Command::EMERGENCY_BRAKE] = &Pod_State::emergency_brake;
-  transition_map[Command::TRANS_ERROR_STATE]= &Pod_State::error;
+  transition_map[Command::TRANS_ERROR_STATE]= &Pod_State::abort;
   // non state transition commands
   transition_map[Command::ENABLE_MOTOR] = &Pod_State::no_transition;
   transition_map[Command::DISABLE_MOTOR] = &Pod_State::no_transition;
@@ -35,7 +29,7 @@ Pod_State::Pod_State()
   steady_state_map[ST_FLIGHT_ACCEL] = &Pod_State::steady_flight_accelerate;
   steady_state_map[ST_FLIGHT_COAST] = &Pod_State::steady_flight_coast;
   steady_state_map[ST_FLIGHT_BRAKE] = &Pod_State::steady_flight_brake;
-  steady_state_map[ST_ERROR] = &Pod_State::steady_error_state;
+  steady_state_map[ST_ERROR] = &Pod_State::steady_abort_state;
 }
 
 // returns the current state as a E_States enum
@@ -172,7 +166,7 @@ void Pod_State::brake() {
   END_TRANSITION_MAP(NULL)
 }
 
-void Pod_State::error() {
+void Pod_State::abort() {
   BEGIN_TRANSITION_MAP              /* Current state */
     TRANSITION_MAP_ENTRY(ST_ERROR)        /* Safe Mode */
     TRANSITION_MAP_ENTRY(ST_ERROR)        /* Functional test */
@@ -205,6 +199,7 @@ void Pod_State::ST_Launch_Ready() {
 
 void Pod_State::ST_Flight_Accel() {
   print(LogLevel::LOG_EDEBUG, "STATE : %s\n", get_current_state_string().c_str());
+  acceleration_start_time = microseconds();
   brakes.disable_brakes();
   motor.enable_motors();
   motor.set_throttle(100);
@@ -212,11 +207,13 @@ void Pod_State::ST_Flight_Accel() {
 
 void Pod_State::ST_Flight_Coast() {
   print(LogLevel::LOG_EDEBUG, "STATE : %s\n", get_current_state_string().c_str());
+  coast_start_time = microseconds();
   motor.disable_motors();
 }
 
 void Pod_State::ST_Flight_Brake() {
   print(LogLevel::LOG_EDEBUG, "STATE : %s\n", get_current_state_string().c_str());
+  brake_start_time = microseconds();
   motor.disable_motors();
   brakes.enable_brakes();
 }
@@ -272,11 +269,13 @@ void Pod_State::steady_launch_ready(Command::Network_Command * command,
 void Pod_State::steady_flight_accelerate(Command::Network_Command * command, 
                                         std::shared_ptr<UnifiedState> state) {
   // Access Pos, Vel, and Accel from Motion Model
-  double pos = state->motion_data->x[0];
-  double vel = state->motion_data->x[1];
-  double acc = state->motion_data->x[2];
+  int32_t pos = state->motion_data->x[0];
+  int32_t vel = state->motion_data->x[1];
+  int32_t acc = state->motion_data->x[2];
+  int64_t timeout_check = microseconds() - acceleration_start_time;
   
-  if (shouldBrake(vel, pos) || vel > MAX_VELOCITY) {
+  // Transition if kinematics demand it, or we exceed our timeout
+  if (shouldBrake(vel, pos) || timeout_check >= acceleration_timeout) {
     Command::put(Command::Network_Command_ID::TRANS_FLIGHT_COAST, 0);
     auto_transition_coast.invoke();
   }
@@ -284,13 +283,9 @@ void Pod_State::steady_flight_accelerate(Command::Network_Command * command,
 
 void Pod_State::steady_flight_coast(Command::Network_Command * command, 
                                     std::shared_ptr<UnifiedState> state) {
-  std::shared_ptr<MotionData> motion_data = state->motion_data;
-  double pos = state->motion_data->x[0];
-  double vel = state->motion_data->x[1];
-  double acc = state->motion_data->x[2];
-  
-  
-  if (shouldBrake(vel, pos)) {
+  // Transition after we exceed our timeout
+  int64_t timeout_check = microseconds() - coast_start_time;
+  if (timeout_check >= coast_timeout) {
     Command::put(Command::Network_Command_ID::TRANS_FLIGHT_BRAKE, 0);
     auto_transition_brake.invoke();
   }
@@ -298,14 +293,24 @@ void Pod_State::steady_flight_coast(Command::Network_Command * command,
 
 void Pod_State::steady_flight_brake(Command::Network_Command * command, 
                                     std::shared_ptr<UnifiedState> state) {
-  // Brakes are applied
+  int32_t acc = state->motion_data->x[2];
+  int32_t vel = state->motion_data->x[1];
+  int64_t timeout_check = microseconds() - brake_start_time;
+
+  // Transition after we exceed our timeout AND acceleration AND Velocity are under a configurable value.
+  if (std::abs(acc) < not_moving_velocity 
+      && std::abs(vel) < not_moving_velocity 
+      && timeout_check >= brake_timeout) {
+    Command::put(Command::Network_Command_ID::TRANS_FLIGHT_BRAKE, 0);
+    auto_transition_brake.invoke();
+  }
 }
 
-bool Pod_State::shouldBrake(double vel, double pos) {
-  int32_t target_distance = LENGTH_OF_TRACK - BUFFER_LENGTH;
-  double stopping_distance = pos + -0.5*vel*vel/IDEAL_DECCEL;
+bool Pod_State::shouldBrake(int64_t vel, int64_t pos) {
+  int64_t target_distance = length_of_track - brake_buffer_length;
+  int64_t stopping_distance = pos + (vel * vel) / (2*estimated_brake_deceleration);
 
-  if (stopping_distance > target_distance) {
+  if (stopping_distance >= target_distance) {
     print(LogLevel::LOG_INFO, "Pod Should Brake, vel: %.2f pos: %.2f\n", vel, pos);
     return true;
   } else {
@@ -313,6 +318,6 @@ bool Pod_State::shouldBrake(double vel, double pos) {
   }
 }
 
-void Pod_State::steady_error_state(Command::Network_Command * command, 
+void Pod_State::steady_abort_state(Command::Network_Command * command, 
                                     std::shared_ptr<UnifiedState> state) {
 }

--- a/CentralComputing/Pod_State.h
+++ b/CentralComputing/Pod_State.h
@@ -35,12 +35,13 @@ class Pod_State : public StateMachine {
       "FLIGHT_ACCEL",
       "FLIGHT_COAST",
       "FLIGHT_BRAKE",
-      "ERROR_STATE",
+      "ABORT_STATE",
       "NOT A STATE"
     };
     return states[static_cast<int>(get_current_state())];
   }
   
+  // The following functions define transition maps for the state diagram
   /**
   * User controlled movement events
   **/
@@ -59,7 +60,7 @@ class Pod_State : public StateMachine {
   **/
   void coast();
   void brake();
-  void error();
+  void abort();
 
   /**
   * Steady state functions
@@ -73,7 +74,7 @@ class Pod_State : public StateMachine {
   void steady_flight_accelerate(Command::Network_Command*, std::shared_ptr<UnifiedState>);
   void steady_flight_coast(Command::Network_Command*, std::shared_ptr<UnifiedState>);
   void steady_flight_brake(Command::Network_Command*, std::shared_ptr<UnifiedState>);
-  void steady_error_state(Command::Network_Command*, std::shared_ptr<UnifiedState>);
+  void steady_abort_state(Command::Network_Command*, std::shared_ptr<UnifiedState>);
 
   /*
   * Gets the steady state function for the current state
@@ -97,6 +98,18 @@ class Pod_State : public StateMachine {
   Event auto_transition_brake;
     
  private:
+  // variables used to measure time in a state, and configurable timeout values
+  int64_t acceleration_start_time, acceleration_timeout;
+  int64_t coast_start_time, coast_timeout;
+  int64_t brake_start_time, brake_timeout;
+
+  // variables used to determine when to exit acceleration
+  int64_t estimated_brake_deceleration;
+  int64_t length_of_track;
+  int64_t brake_buffer_length;
+  int64_t not_moving_acceleration;
+  int64_t not_moving_velocity;
+
   std::map<Command::Network_Command_ID, transition_function> transition_map; 
   
   std::map<E_States, steady_state_function> steady_state_map;
@@ -108,7 +121,7 @@ class Pod_State : public StateMachine {
   void ST_Flight_Coast();
   void ST_Flight_Brake();
   void ST_Error();
-  bool shouldBrake(double, double);
+  bool shouldBrake(int64_t, int64_t);
 
 
 

--- a/CentralComputing/defaultConfig.txt
+++ b/CentralComputing/defaultConfig.txt
@@ -1,9 +1,9 @@
-tmp_manager_timeout 100000.0
-i2c_manager_timeout 100000.0
-can_manager_timeout 100000.0
-adc_manager_timeout 100000.0
-pru_manager_timeout 100000.0
-logic_loop_timeout  1000.0
+tmp_manager_timeout 100000.0 # Units are microseconds
+i2c_manager_timeout 100000.0 # Units are microseconds
+can_manager_timeout 100000.0 # Units are microseconds 
+adc_manager_timeout 100000.0 # Units are microseconds
+pru_manager_timeout 100000.0 # Units are microseconds
+logic_loop_timeout  1000.0   # Units are microseconds
 
 tcp_port 8001
 tcp_addr 127.0.0.1
@@ -14,4 +14,17 @@ udp_addr 127.0.0.1
 
 low_pass_filter_velocity 0.90
 low_pass_filter_acceleration 0.90
-motor_distance_clamp 60960
+motor_distance_clamp 60960    
+
+acceleration_timeout 10000000 # Units are microseconds
+coast_timeout 200000          # Units are microseconds
+brake_timeout 10000000        # Units are microseconds
+
+estimated_brake_deceleration 9810 # Units are mm/s/s
+
+length_of_track     1250000  # Units are mm
+brake_buffer_length 50000    # Units are mm
+
+not_moving_velocity     200  # Units are mm/s
+not_moving_acceleration 200  # Units are mm/s
+

--- a/CentralComputing/scenarios/Scenario.hpp
+++ b/CentralComputing/scenarios/Scenario.hpp
@@ -53,7 +53,7 @@ class Scenario{
 
   void sim_motor_enable() {
     motorsOn = true;
-    motors_on = microseconds();
+    motors_on_time = microseconds();
   }
   
   void sim_motor_disable() {
@@ -66,6 +66,7 @@ class Scenario{
   
   void sim_brake_enable() {
     brakesOn = true;
+    brakes_on_time = microseconds();
   }
   
   void sim_brake_disable() {
@@ -88,7 +89,8 @@ class Scenario{
   double velocity = 0.000;
   double lastVelocity = 0.000;
   double acceleration = 0.000;
-  int64_t motors_on = 0;
+  int64_t motors_on_time = 0;
+  int64_t brakes_on_time= 0;
 
 };
 #endif 

--- a/CentralComputing/scenarios/ScenarioBasic.cpp
+++ b/CentralComputing/scenarios/ScenarioBasic.cpp
@@ -8,6 +8,7 @@ bool ScenarioBasic::use_motion_model() {
   return true;
 }
 
+// This test is designed to do the same thing that the original code in Simulator.cpp did
 std::shared_ptr<MotionData> ScenarioBasic::sim_get_motion() {
   // FOR FIRST CALL
   if (timeLast == -1) {

--- a/CentralComputing/scenarios/ScenarioBasic.cpp
+++ b/CentralComputing/scenarios/ScenarioBasic.cpp
@@ -34,9 +34,9 @@ std::shared_ptr<MotionData> ScenarioBasic::sim_get_motion() {
 
   // CREATING A STATESPACE OBJECT AND SETTING ITS ARRAY'S VALUES
   std::shared_ptr<MotionData> space = std::make_shared<MotionData>();
-  space->x[0] = position;
-  space->x[1] = velocity;
-  space->x[2] = acceleration;
+  space->x[0] = position * 1000; // multiply by 1000 to convert to mm
+  space->x[1] = velocity * 1000; // ^^^^
+  space->x[2] = acceleration * 1000; // ^^^
 
   if (enable_logging) {
     print(LogLevel::LOG_DEBUG, 

--- a/CentralComputing/scenarios/ScenarioRealLong.cpp
+++ b/CentralComputing/scenarios/ScenarioRealLong.cpp
@@ -14,7 +14,7 @@ void ScenarioRealLong::true_motion() {
   double deltaSeconds = static_cast<double>(timeDelta) / 1000000.0;
 
   if (motorsOn) {
-    acceleration = 9 - 2.5 * clamp((microseconds() - motors_on)/10000000.0, 0.0, 1.0);
+    acceleration = 9 - 2.5 * clamp((microseconds() - motors_on_time)/10000000.0, 0.0, 1.0);
   } else if (brakesOn) {
     acceleration = -20;
   } else {

--- a/CentralComputing/scenarios/ScenarioRealLong.cpp
+++ b/CentralComputing/scenarios/ScenarioRealLong.cpp
@@ -37,9 +37,9 @@ bool ScenarioRealLong::use_motion_model() {
 std::shared_ptr<ADCData> ScenarioRealLong::sim_get_adc() {
   true_motion();
   std::shared_ptr<ADCData> d = std::make_shared<ADCData>();
-  d->accel[0] =  acceleration;
-  d->accel[1] =  acceleration;
-  d->accel[2] =  acceleration;
+  d->accel[0] =  acceleration * 1000; // multiply by 1000 to convert to millimeters
+  d->accel[1] =  acceleration * 1000;
+  d->accel[2] =  acceleration * 1000;
   return d;
 }
 
@@ -63,11 +63,11 @@ std::shared_ptr<PRUData> ScenarioRealLong::sim_get_pru() {
     "Motion: Pos: %.2f, Vel: %.2f, Acl: %.2f \n", position, velocity, acceleration );
 
   std::shared_ptr<PRUData> d = std::make_shared<PRUData>();
-  d->wheel_velocity[0] =  velocity;
-  d->wheel_velocity[1] =  velocity;
+  d->wheel_velocity[0] =  velocity * 1000; // multiply by 1000 to convert to millimeters
+  d->wheel_velocity[1] =  velocity * 1000;
 
-  d->orange_distance[0] =  position;
-  d->orange_distance[1] =  d->orange_distance[0];
+  d->orange_distance[0] =  position * 1000; // multiply by 1000 to convert to millimeters
+  d->orange_distance[1] = d->orange_distance[0];
   d->wheel_distance[0] =  d->orange_distance[0];
   d->wheel_distance[1] =  d->orange_distance[0];
 

--- a/CentralComputing/scenarios/ScenarioRealLong.h
+++ b/CentralComputing/scenarios/ScenarioRealLong.h
@@ -12,7 +12,7 @@ class ScenarioRealLong : public Scenario {
   std::shared_ptr<I2CData> sim_get_i2c();
   std::shared_ptr<PRUData> sim_get_pru();
 
-  void true_motion();
+  virtual void true_motion();
   int64_t pru_delta_seconds, can_delta_seconds;
 };
 #endif

--- a/CentralComputing/scenarios/ScenarioRealNoFault.cpp
+++ b/CentralComputing/scenarios/ScenarioRealNoFault.cpp
@@ -33,6 +33,11 @@ std::shared_ptr<ADCData> ScenarioRealNoFault::sim_get_adc() {
     d->accel[2] =  0;
     acceleration = 0;
   }
+
+  // Multiply by 1000 to convert to millimeters
+  d->accel[0] *= 1000;
+  d->accel[1] *= 1000;
+  d->accel[2] *= 1000; 
   return d;
 }
 
@@ -65,6 +70,12 @@ std::shared_ptr<PRUData> ScenarioRealNoFault::sim_get_pru() {
   lastPosition = position;
   lastVelocity = velocity;
   pru_delta_seconds = microseconds();
+  d->wheel_velocity[0] *= 1000; // multiply by 1000 to convert to millimeters
+  d->wheel_velocity[1] *= 1000;
+  d->orange_distance[0] *= 1000; 
+  d->orange_distance[1] *= 1000;
+  d->wheel_distance[0]  *= 1000; 
+  d->wheel_distance[1]  *= 1000; 
   return d;
 }
 

--- a/CentralComputing/scenarios/ScenarioTestTimeouts.cpp
+++ b/CentralComputing/scenarios/ScenarioTestTimeouts.cpp
@@ -1,0 +1,27 @@
+#ifdef SIM
+#include "ScenarioTestTimeouts.h"
+#include "Utils.h"
+using Utils::microseconds;
+using Utils::clamp;
+
+ScenarioTestTimeouts::ScenarioTestTimeouts() {
+}
+
+void ScenarioTestTimeouts::true_motion() {
+  timeDelta = Utils::microseconds() - timeLast;
+  double deltaSeconds = static_cast<double>(timeDelta) / 1000000.0;
+
+  if (motorsOn) {
+    acceleration = 0; 
+  } else if (brakesOn) {
+    acceleration = 0;
+    velocity = 0;
+  } else {
+    acceleration = 0;
+  }
+
+  timeLast = Utils::microseconds();
+}
+
+
+#endif

--- a/CentralComputing/scenarios/ScenarioTestTimeouts.h
+++ b/CentralComputing/scenarios/ScenarioTestTimeouts.h
@@ -1,0 +1,10 @@
+#ifndef SCENARIOTESTTIMEOUTS_H_
+#define SCENARIOTESTTIMEOUTS_H_
+#include "ScenarioRealLong.h"
+
+class ScenarioTestTimeouts: public ScenarioRealLong {
+ public:
+  ScenarioTestTimeouts();
+  virtual void true_motion();
+};
+#endif

--- a/CentralComputing/tests/AutoTests.cpp
+++ b/CentralComputing/tests/AutoTests.cpp
@@ -135,6 +135,7 @@ TEST_F(PodTest, AutomaticTransitionTestTimeouts) {
   pod->processing_command.reset();
   pod->state_machine->auto_transition_brake.wait();
   EXPECT_GT(microseconds()-c_start, coast_timeout); // test to make sure that we waited the correct ammount of time
+  EXPECT_LT(microseconds()-c_start, coast_timeout*2); // test to make sure that we are bounded 
   pod->processing_command.wait();
   EXPECT_EQ(pod->state_machine->get_current_state(), E_States::ST_FLIGHT_BRAKE);
 

--- a/CentralComputing/tests/AutoTests.cpp
+++ b/CentralComputing/tests/AutoTests.cpp
@@ -3,6 +3,7 @@
 #include "ScenarioBasic.h"
 #include "ScenarioRealNoFault.h"
 #include "ScenarioRealLong.h"
+#include "ScenarioTestTimeouts.h"
 using std::make_shared;
 
 TEST_F(PodTest, AutomaticTransitionBasic) {
@@ -90,6 +91,50 @@ TEST_F(PodTest, AutomaticTransitionLong) {
 
   pod->processing_command.reset();
   pod->state_machine->auto_transition_brake.wait();
+  pod->processing_command.wait();
+  EXPECT_EQ(pod->state_machine->get_current_state(), E_States::ST_FLIGHT_BRAKE);
+
+}
+
+TEST_F(PodTest, AutomaticTransitionTestTimeouts) {
+  SimulatorManager::sim.set_scenario(make_shared<ScenarioTestTimeouts>());
+  MoveState(Command::Network_Command_ID::TRANS_FUNCTIONAL_TEST, E_States::ST_FUNCTIONAL_TEST, true);
+  MoveState(Command::Network_Command_ID::TRANS_LOADING, E_States::ST_LOADING, true);
+  MoveState(Command::Network_Command_ID::TRANS_LAUNCH_READY, E_States::ST_LAUNCH_READY, true);
+
+  // Get the times we are supposed to wait
+  int64_t acceleration_timeout, coast_timeout, brake_timeout;
+  if (!(ConfiguratorManager::config.getValue("acceleration_timeout", acceleration_timeout) && 
+      ConfiguratorManager::config.getValue("coast_timeout", coast_timeout) &&
+      ConfiguratorManager::config.getValue("brake_timeout", brake_timeout))){
+        print(LogLevel::LOG_ERROR, "CONFIG FILE ERROR: SCENARIO_TEST_TIMEOUTS: Missing necessary configuration\n");
+        exit(1);
+  }
+  int64_t a_start = microseconds(); // time how long acceleration state takes
+  MoveState(Command::Network_Command_ID::LAUNCH, E_States::ST_FLIGHT_ACCEL, true); // launch into accel state
+  EXPECT_TRUE(pod->state_machine->motor.is_enabled()); // make sure motor is on
+
+  pod->processing_command.reset();
+  pod->state_machine->auto_transition_coast.wait(); // trigger transition to coast
+  EXPECT_GT(microseconds()-a_start, acceleration_timeout); // test to make sure that we waited the correct ammount of time
+  int64_t c_start = microseconds(); // time how long coast state takes
+  pod->processing_command.wait(); // wait for transition to process in Pod
+
+
+  // There is a EDGE CASE where in the time since we entered Launch/acceleration, that we have already transitioned through coast and into brake
+  // such that the following line failes.
+  // Then when pod->process_command.wait() happens, it waits forever since that command will never happen.
+  // Thus why we have this weird if statement here.
+  if(pod->state_machine->get_current_state() == E_States::ST_FLIGHT_BRAKE){
+    EXPECT_EQ(pod->state_machine->get_current_state(), E_States::ST_FLIGHT_BRAKE);
+    return;
+  }
+  EXPECT_EQ(pod->state_machine->get_current_state(), E_States::ST_FLIGHT_COAST);
+
+
+  pod->processing_command.reset();
+  pod->state_machine->auto_transition_brake.wait();
+  EXPECT_GT(microseconds()-c_start, coast_timeout); // test to make sure that we waited the correct ammount of time
   pod->processing_command.wait();
   EXPECT_EQ(pod->state_machine->get_current_state(), E_States::ST_FLIGHT_BRAKE);
 

--- a/CentralComputing/tests/test.txt
+++ b/CentralComputing/tests/test.txt
@@ -1,7 +1,7 @@
-Variable 12
-Number 2342
+Variable 12 // test comment
+Number 2342 // test comment
 MaxAccel 1231.23
 MaxDecel 231
-motor_distance_clamp 10
+motor_distance_clamp 10 wow
 low_pass_filter_velocity 0.90
 low_pass_filter_acceleration 0.90


### PR DESCRIPTION
This pull request sets up automatic transitions from Flight states. 

For example, you can now configure how long the pod will be in the Acceleration state before it automatically exits it. Look at `defaultConfig.txt` for more information. 

An additional test is implemented for this, and it uses a scenario that just defines all kinematics to be 0.
