### PR TITLE
Pod4 command length

### DIFF
--- a/CentralComputing/Command.cpp
+++ b/CentralComputing/Command.cpp
@@ -1,26 +1,26 @@
 #include "Command.h"
 
-SafeQueue<uint16_t> Command::command_queue;
+SafeQueue<uint64_t> Command::command_queue;
 int64_t Command::error_flag_timers[8*6]; 
 
-void Command::put(uint8_t id, uint8_t value) {
-  uint16_t toQueue = (id << 8) | value;
+void Command::put(uint32_t id, uint32_t value) {
+  uint64_t toQueue = (uint64_t)(((uint64_t)id) << 32) | (uint64_t)(value & 0xFFFFFFFF);
   command_queue.enqueue(toQueue);
 }
 
 bool Command::get(Network_Command * com) {
-  uint16_t preShift;
+  uint64_t preShift;
   if (!command_queue.dequeue(&preShift)) {
     return false;
   }
-  com->value = static_cast<uint8_t>(preShift);
-  com->id = static_cast<uint8_t>(preShift >> 8);
+  com->value = static_cast<uint32_t>(preShift & 0xFFFFFFFF);
+  com->id = static_cast<uint32_t>(preShift >> 32);
   return true;
 }
 
 // Used in set_error_flag to not flood the command queue
 // See the .h for more explanation
-void Command::set_error_flag(uint8_t id, uint8_t value) {
+void Command::set_error_flag(uint32_t id, uint32_t value) {
   // Initialize if this is the first function call
   static bool first_time = 1;
   if (first_time) {
@@ -31,13 +31,13 @@ void Command::set_error_flag(uint8_t id, uint8_t value) {
     first_time = 0;
   }
 
-  for (int i = 0, j = 1; i < 8; i++, j*=2) {  // Go through each bit of the flag  
+  for (uint i = 0, j = 1; i < 24; i++, j*=2) {  // Go through each bit of the flag  
     if (value & j) {  // if the specific bit is on
       // Determine the time delta, use the error_flag_timers
       int64_t delta = Utils::microseconds() - error_flag_timers[(id-Command::SET_ADC_ERROR) * 8 + i]; 
       if (delta > 1000000) {  // Delta is greater than 1 second. This means we only send once per second!
         error_flag_timers[(id-Command::SET_ADC_ERROR) * 8 + i] = Utils::microseconds();
-        Command::put(id, value & j);  // put command on queue
+        Command::put(id, (value & j));  // put command on queue
       }
     }
   }

--- a/CentralComputing/Command.h
+++ b/CentralComputing/Command.h
@@ -66,8 +66,8 @@ enum Network_Data_ID {
 
 struct Network_Command {
   // state transtitions
-  uint32_t id;  // id is a Network_Command_ID
-  uint32_t value;  // value of a command, up to 24 bits  
+  uint32_t id;     // id is a Network_Command_ID
+  uint32_t value;  // value of a command
 };
 
 // To make error flag setting easy, this helper functionn is defined

--- a/CentralComputing/Command.h
+++ b/CentralComputing/Command.h
@@ -17,9 +17,9 @@
 
 namespace Command {
 
-extern SafeQueue<uint16_t> command_queue;
+extern SafeQueue<uint64_t> command_queue;
 struct Network_Command;
-void put(uint8_t id, uint8_t value);
+void put(uint32_t id, uint32_t value);
 bool get(Network_Command * com);
   
 enum Network_Command_ID {
@@ -66,8 +66,8 @@ enum Network_Data_ID {
 
 struct Network_Command {
   // state transtitions
-  uint8_t id;  // id is just a network command
-  uint8_t value;
+  uint32_t id;  // id is a Network_Command_ID
+  uint32_t value;  // value of a command, up to 24 bits  
 };
 
 // To make error flag setting easy, this helper functionn is defined
@@ -77,7 +77,7 @@ struct Network_Command {
 // But then it send another command to the Unified Queue once every second. 
 // This helper function, and the int64_t array of timers makes that possible
 extern int64_t error_flag_timers[8*6];  // 8 flags per error ID, 6 errors
-void set_error_flag(uint8_t id, uint8_t value);
+void set_error_flag(uint32_t id, uint32_t value);
 
 }  // namespace Command
 

--- a/CentralComputing/Simulator.cpp
+++ b/CentralComputing/Simulator.cpp
@@ -144,7 +144,7 @@ void Simulator::sim_motor_disable() {
   }
 }
 
-void Simulator::sim_motor_set_throttle(uint8_t value) {
+void Simulator::sim_motor_set_throttle(int16_t value) {
   std::lock_guard<std::mutex> guard(mutex);
   print(LogLevel::LOG_DEBUG, "Sim - Setting motor throttle: %d\n", value);
   if (scenario != nullptr) {

--- a/CentralComputing/Simulator.h
+++ b/CentralComputing/Simulator.h
@@ -98,7 +98,7 @@ class Simulator {
     * Simulates setting the motor throttle to a specific value
     * param value the new throttle value
     */
-  void sim_motor_set_throttle(uint8_t value);
+  void sim_motor_set_throttle(int16_t value);
 
   /*
     * Simulates enabling the brakes

--- a/CentralComputing/TCPManager.cpp
+++ b/CentralComputing/TCPManager.cpp
@@ -47,11 +47,11 @@ int TCPManager::connect_to_server(const char * hostname, const char * port) {
   return socketfd;
 }
 
-int TCPManager::read_command(uint8_t * ID, uint8_t * Command) {
-  uint8_t bytes[2];
-  int bytes_read = read(socketfd, bytes, 2);
-  *ID = (Command::Network_Command_ID) bytes[0];
-  *Command = bytes[1];
+int TCPManager::read_command(uint32_t * ID, uint32_t * Command) {
+  uint8_t bytes[8];
+  int bytes_read = read(socketfd, bytes, sizeof(bytes));
+  *ID =  *((uint32_t *)bytes);
+  *Command = *((uint32_t *) (bytes+4));
   return bytes_read;
 }
 
@@ -69,13 +69,13 @@ int TCPManager::write_data() {
 
 void TCPManager::read_loop() {
   bool active_connection = true;
-  uint8_t ID;
-  uint8_t Command;
+  uint32_t ID;
+  uint32_t Command;
   while (running && active_connection) {
     int bytes_read = read_command(&ID, &Command);
     active_connection = bytes_read > 0;
     if (bytes_read > 0) {
-      // print(LogLevel::LOG_EDEBUG, "Bytes read: %d Read command %d %d\n", bytes_read, buffer.id, buffer.value);
+      print(LogLevel::LOG_EDEBUG, "Bytes read: %d Read command %d %d\n", bytes_read, ID, Command);
       Command::put(ID, Command);
     }
   }

--- a/CentralComputing/TCPManager.cpp
+++ b/CentralComputing/TCPManager.cpp
@@ -48,7 +48,7 @@ int TCPManager::connect_to_server(const char * hostname, const char * port) {
 }
 
 int TCPManager::read_command(uint32_t * ID, uint32_t * Command) {
-  uint8_t bytes[8];
+  uint8_t bytes[sizeof(Command::Network_Command)];
   int bytes_read = read(socketfd, bytes, sizeof(bytes));
   *ID =  *((uint32_t *)bytes);
   *Command = *((uint32_t *) (bytes+4));

--- a/CentralComputing/TCPManager.h
+++ b/CentralComputing/TCPManager.h
@@ -42,7 +42,7 @@ int connect_to_server(const char * hostname, const char * port);
  * @param buffer a pointer to the network command that was read
  * @return the number of bytes read
  **/
-int read_command(uint8_t * ID, uint8_t * Command); 
+int read_command(uint32_t * ID, uint32_t * Command); 
 /** 
  * Collects data from sensor, writes to socket
  * @return bytes written or -1 if failed

--- a/CentralComputing/scenarios/Scenario.hpp
+++ b/CentralComputing/scenarios/Scenario.hpp
@@ -60,7 +60,7 @@ class Scenario{
     motorsOn = false;
   }
   
-  void sim_motor_set_throttle(uint8_t value) {
+  void sim_motor_set_throttle(int16_t value) {
     throttle = value;
   }
   
@@ -82,7 +82,7 @@ class Scenario{
   int64_t timeDelta = 0.000;
   bool motorsOn = false;
   bool brakesOn = false;
-  uint8_t throttle = 0.000;
+  int16_t throttle = 0.000;
   uint8_t pressure = 0.000;
   double position = 0.000;
   double lastPosition = 0.000;

--- a/CentralComputing/tests/PodTest.cpp
+++ b/CentralComputing/tests/PodTest.cpp
@@ -60,7 +60,7 @@ class PodTest : public ::testing::Test
    * @param id the id of the command to run
    * @param value the value for the command
    */
-  void SendCommand(Command::Network_Command_ID id, uint8_t value) {
+  void SendCommand(Command::Network_Command_ID id, uint32_t value) {
 
     auto command = std::make_shared<Command::Network_Command>();
     command->id = id;


### PR DESCRIPTION
Updating the Command Length from 1 byte ID and 1 byte value to 4 byte ID and 4 byte value.

This future-proofs any sort of command that might be needed, and allows larger command values, which is useful to control the motor (need at least 16 bits).

The cost to send 8 bytes vs. 2 bytes is practically nothing. 