### PR TITLE
Pod4 add no action mode

### DIFF
--- a/CentralComputing/Brakes.cpp
+++ b/CentralComputing/Brakes.cpp
@@ -5,22 +5,32 @@ Brakes::Brakes() {
 }
 
 void Brakes::enable_brakes() {
-  #ifdef SIM
-  SimulatorManager::sim.sim_brake_enable();
-
+  #ifdef NO_ACTION
+    #ifdef SIM
+    SimulatorManager::sim.sim_brake_enable();
+    #else 
+    print(LogLevel::LOG_INFO, "NO_ACTION: Brakes Enabled\n");
+    #endif
+  #else
+  // Do actually something to enable brakes
+  print(LogLevel::LOG_DEBUG, "Brakes Enabled\n");
   #endif
   enabled = true;
-  print(LogLevel::LOG_DEBUG, "Brakes Enabled\n");
 }
 
 void Brakes::disable_brakes() {
-  #ifdef SIM
-  SimulatorManager::sim.sim_brake_disable();
-
+  #ifdef NO_ACTION
+    #ifdef SIM
+    SimulatorManager::sim.sim_brake_disable();
+    #else
+    print(LogLevel::LOG_INFO, "NO_ACTION: Brakes Disabled\n"); 
+    #endif
+  #else
+  // Do actually something to disable brakes
+  print(LogLevel::LOG_DEBUG, "Brakes Disabled\n");
   #endif
 
   enabled = false;
-  print(LogLevel::LOG_DEBUG, "Brakes Disabled\n");
 }
 
 void Brakes::set_enable(bool enable) {

--- a/CentralComputing/Makefile
+++ b/CentralComputing/Makefile
@@ -17,9 +17,9 @@ WARNINGS 	:= -Wall -Wextra -pedantic -Wdouble-promotion -Wcast-align -Wcast-qual
 
 
 INCLUDE_DIRS	:= -IStateMachineCompact -I${GTEST_DIR}/include -I. -Iscenarios
-CFLAGS_RELEASE 	:= -O2 $(WARNINGS) -g -std=c++11 -c -MMD -MP $(INCLUDE_DIRS) -D_GNU_SOURCE -pthread -DNDEBUG
-CFLAGS_DEBUG   	:= -O0 $(WARNINGS) -g -std=c++11 -c -MMD -MP $(INCLUDE_DIRS) -D_GNU_SOURCE -pthread -DDEBUG 
+CFLAGS_RELEASE 		:= -O2 $(WARNINGS) -g -std=c++11 -c -MMD -MP $(INCLUDE_DIRS) -D_GNU_SOURCE -pthread -DNDEBUG
 CFLAGS_RELEASE_NA	:= -O2 $(WARNINGS) -g -std=c++11 -c -MMD -MP $(INCLUDE_DIRS) -D_GNU_SOURCE -pthread -DNDEBUG -DNO_ACTION
+CFLAGS_DEBUG   		:= -O0 $(WARNINGS) -g -std=c++11 -c -MMD -MP $(INCLUDE_DIRS) -D_GNU_SOURCE -pthread -DDEBUG 
 CFLAGS_DEBUG_NA 	:= -O0 $(WARNINGS) -g -std=c++11 -c -MMD -MP $(INCLUDE_DIRS) -D_GNU_SOURCE -pthread -DDEBUG  -DNO_ACTION
 CFLAGS_SIM 		:= -O0 $(WARNINGS) -g -std=c++11 -c -MMD -MP $(INCLUDE_DIRS) -D_GNU_SOURCE -pthread -DDEBUG  -DNO_ACTION -DSIM 
 CFLAGS_BBB      := -DBBB
@@ -36,9 +36,7 @@ LD_BBB  := $(CXX_BBB)
 
 # Define all executables
 POD 		= build
-POD_NA 		= build-na
 POD_D 		= dbuild
-POD_D_NA 	= dbuild-na
 POD_T 		= sbuild
 POD_CROSS 	= cross
 POD_CROSS_NA 	= cross-na
@@ -50,7 +48,7 @@ ARM_COMPILER_EXISTS := $(shell command -v $(CXX_BBB) 2> /dev/null)
 
 
 .PHONY: all
-all : msg mkdir_obj ${LIB_DIR}/gtest-all.o ${LIB_DIR}/gtest-all-arm.o msg_d $(POD_D_NA)-tsan msg_s $(POD_T)-tsan
+all : msg mkdir_obj ${LIB_DIR}/gtest-all.o ${LIB_DIR}/gtest-all-arm.o msg_d $(POD_D)-tsan msg_s $(POD_T)-tsan
 	$(info  =   ___ _   _  ___ ___ ___  ___ ___  )
 	$(info	=  / __| | | |/ __/ __/ _ \/ __/ __| )
 	${info	=  \__ \ |_| | (_| (_|  __/\__ \__ \ }
@@ -148,7 +146,7 @@ $(POD)-asan : CXX_NORM := $(CXX_NORM) -fsanitize=address
 $(POD)-asan : $(POD)  #JUMP TO POD to continue compiling
 
 $(POD) : CXX 	= $(CXX_NORM)
-$(POD) : CFLAGS = $(CFLAGS_RELEASE) $(CFLAGS_NORM)
+$(POD) : CFLAGS = $(CFLAGS_RELEASE_NA) $(CFLAGS_NORM)
 $(POD) : LD  	= $(LD_NORM)
 $(POD) : mkdir_obj build-$(POD)
 build-$(POD) : $(OBJ:%.o=$(OBJ_DIR)/%-build.o)
@@ -157,26 +155,6 @@ build-$(POD) : $(OBJ:%.o=$(OBJ_DIR)/%-build.o)
 $(OBJ_DIR)/%-build.o : %.cpp
 	$(CXX) $? $(CFLAGS) -o $@
 
-#####
-# build-na
-#####
-$(POD_NA)-tsan : LD_NORM := $(LD_NORM) -fsanitize=thread
-$(POD_NA)-tsan : CXX_NORM := $(CXX_NORM) -fsanitize=thread -fPIE -pie
-$(POD_NA)-tsan : $(POD)  #JUMP TO POD to continue compiling
-
-$(POD_NA)-asan : LD_NORM := $(LD_NORM) -fsanitize=address
-$(POD_NA)-asan : CXX_NORM := $(CXX_NORM) -fsanitize=address 
-$(POD_NA)-asan : $(POD)  #JUMP TO POD to continue compiling
-
-$(POD_NA) : CXX 	= $(CXX_NORM)
-$(POD_NA) : CFLAGS 	= $(CFLAGS_RELEASE_NA) $(CFLAGS_NORM)
-$(POD_NA) : LD  	= $(LD_NORM)
-$(POD_NA) : mkdir_obj build-$(POD_NA)
-build-$(POD_NA) : $(OBJ:%.o=$(OBJ_DIR)/%-build.o)
-	$(LD) $? $(LDFLAGS) $(LD_TEST_NORM)  -o $(POD_NA)
-
-$(OBJ_DIR)/%-build.o : %.cpp
-	$(CXX) $? $(CFLAGS) -o $@
 
 #####
 # build-debug
@@ -190,32 +168,11 @@ $(POD_D)-asan : CXX_NORM := $(CXX_NORM) -fsanitize=address
 $(POD_D)-asan : $(POD_D)  #JUMP TO POD to continue compiling
 
 $(POD_D) : CXX		= $(CXX_NORM)
-$(POD_D) : CFLAGS  	= $(CFLAGS_DEBUG) $(CFLAGS_NORM)
+$(POD_D) : CFLAGS  	= $(CFLAGS_DEBUG_NA) $(CFLAGS_NORM)
 $(POD_D) : LD  		= $(LD_NORM)
 $(POD_D) : mkdir_obj build-$(POD_D)
 build-$(POD_D) : $(OBJ:%.o=$(OBJ_DIR)/%-build-debug.o)
 	$(LD) $? $(LDFLAGS) $(LD_TEST_NORM) -o $(POD_D)
-
-$(OBJ_DIR)/%-build-debug.o : %.cpp
-	$(CXX) $? $(CFLAGS) -o $@
-
-#####
-# build-debug-na
-#####
-$(POD_D_NA)-tsan : LD_NORM := $(LD_NORM) -fsanitize=thread
-$(POD_D_NA)-tsan : CXX_NORM := $(CXX_NORM) -fsanitize=thread -fPIE -pie
-$(POD_D_NA)-tsan : $(POD_D)  #JUMP TO POD to continue compiling
-
-$(POD_D_NA)-asan : LD_NORM := $(LD_NORM) -fsanitize=address
-$(POD_D_NA)-asan : CXX_NORM := $(CXX_NORM) -fsanitize=address 
-$(POD_D_NA)-asan : $(POD_D)  #JUMP TO POD to continue compiling
-
-$(POD_D_NA) : CXX		= $(CXX_NORM)
-$(POD_D_NA) : CFLAGS  		= $(CFLAGS_DEBUG_NA) $(CFLAGS_NORM)
-$(POD_D_NA) : LD  		= $(LD_NORM)
-$(POD_D_NA) : mkdir_obj build-$(POD_D_NA)
-build-$(POD_D_NA) : $(OBJ:%.o=$(OBJ_DIR)/%-build-debug.o)
-	$(LD) $? $(LDFLAGS) $(LD_TEST_NORM) -o $(POD_D_NA)
 
 $(OBJ_DIR)/%-build-debug.o : %.cpp
 	$(CXX) $? $(CFLAGS) -o $@
@@ -262,10 +219,10 @@ $(POD_CROSS_NA) : CXX 		= $(CXX_BBB)
 $(POD_CROSS_NA) : CFLAGS  	= $(CFLAGS_RELEASE_NA) $(CFLAGS_BBB)
 $(POD_CROSS_NA) : LD  		= $(LD_BBB)
 $(POD_CROSS_NA) : mkdir_obj build-$(POD_CROSS_NA)
-build-$(POD_CROSS_NA) : $(OBJ:%.o=$(OBJ_DIR)/%-cross.o)
+build-$(POD_CROSS_NA) : $(OBJ:%.o=$(OBJ_DIR)/%-cross-na.o)
 	$(LD) $? $(LDFLAGS) $(LD_TEST_ARM) -o $(POD_CROSS_NA)
 
-$(OBJ_DIR)/%-cross.o : %.cpp
+$(OBJ_DIR)/%-cross-na.o : %.cpp
 	$(CXX) $? $(CFLAGS) -o $@
 
 #####
@@ -287,11 +244,11 @@ $(OBJ_DIR)/%-cross-debug.o : %.cpp
 $(POD_CROSS_D_NA) : CXX 	= $(CXX_BBB)
 $(POD_CROSS_D_NA) : CFLAGS 	= $(CFLAGS_DEBUG_NA) $(CFLAGS_BBB)
 $(POD_CROSS_D_NA) : LD     	= $(LD_BBB)
-$(POD_CROSS_D_NA) : mkdir_obj build-$(POD_CROSS_D)
-build-$(POD_CROSS_D_NA) : $(OBJ:%.o=$(OBJ_DIR)/%-cross-debug.o)
-	$(CXX) $? $(LDFLAGS) $(LD_TEST_ARM) -o $(POD_CROSS_D)
+$(POD_CROSS_D_NA) : mkdir_obj build-$(POD_CROSS_D_NA)
+build-$(POD_CROSS_D_NA) : $(OBJ:%.o=$(OBJ_DIR)/%-cross-debug-na.o)
+	$(CXX) $? $(LDFLAGS) $(LD_TEST_ARM) -o $(POD_CROSS_D_NA)
 
-$(OBJ_DIR)/%-cross-debug.o : %.cpp
+$(OBJ_DIR)/%-cross-debug-na.o : %.cpp
 	$(LD) $? $(CFLAGS) -o $@
 
 #####
@@ -309,7 +266,7 @@ $(OBJ_DIR)/%-cross-sim.o : %.cpp
 
 .PHONY: clean
 clean:
-	rm -f $(POD) $(POD_D) $(POD_T) $(POD_CROSS) $(POD_CROSS_D) $(POD_CROSS_T) $(POD_NA) $(POD_D_NA) $(POD_CROSS_NA) $(POD_CROSS_D_NA)
+	rm -f $(POD) $(POD_D) $(POD_T) $(POD_CROSS) $(POD_CROSS_D) $(POD_CROSS_T) $(POD_CROSS_NA) $(POD_CROSS_D_NA)
 	rm -rf $(OBJ_DIR)/  
 
 .PHONY: clean_lib

--- a/CentralComputing/Makefile
+++ b/CentralComputing/Makefile
@@ -19,7 +19,9 @@ WARNINGS 	:= -Wall -Wextra -pedantic -Wdouble-promotion -Wcast-align -Wcast-qual
 INCLUDE_DIRS	:= -IStateMachineCompact -I${GTEST_DIR}/include -I. -Iscenarios
 CFLAGS_RELEASE 	:= -O2 $(WARNINGS) -g -std=c++11 -c -MMD -MP $(INCLUDE_DIRS) -D_GNU_SOURCE -pthread -DNDEBUG
 CFLAGS_DEBUG   	:= -O0 $(WARNINGS) -g -std=c++11 -c -MMD -MP $(INCLUDE_DIRS) -D_GNU_SOURCE -pthread -DDEBUG 
-CFLAGS_SIM 	:= -O0 $(WARNINGS) -g -std=c++11 -c -MMD -MP $(INCLUDE_DIRS) -D_GNU_SOURCE -pthread -DDEBUG -DSIM 
+CFLAGS_RELEASE_NA	:= -O2 $(WARNINGS) -g -std=c++11 -c -MMD -MP $(INCLUDE_DIRS) -D_GNU_SOURCE -pthread -DNDEBUG -DNO_ACTION
+CFLAGS_DEBUG_NA 	:= -O0 $(WARNINGS) -g -std=c++11 -c -MMD -MP $(INCLUDE_DIRS) -D_GNU_SOURCE -pthread -DDEBUG  -DNO_ACTION
+CFLAGS_SIM 		:= -O0 $(WARNINGS) -g -std=c++11 -c -MMD -MP $(INCLUDE_DIRS) -D_GNU_SOURCE -pthread -DDEBUG  -DNO_ACTION -DSIM 
 CFLAGS_BBB      := -DBBB
 CFLAGS_NORM     := 
 #Set up linker
@@ -33,18 +35,22 @@ LD_NORM := $(CXX_NORM)
 LD_BBB  := $(CXX_BBB)
 
 # Define all executables
-POD = build
-POD_D = dbuild
-POD_T = sbuild
-POD_CROSS = cross
-POD_CROSS_D = dcross
-POD_CROSS_T = scross
+POD 		= build
+POD_NA 		= build-na
+POD_D 		= dbuild
+POD_D_NA 	= dbuild-na
+POD_T 		= sbuild
+POD_CROSS 	= cross
+POD_CROSS_NA 	= cross-na
+POD_CROSS_D 	= dcross
+POD_CROSS_D_NA 	= dcross-na
+POD_CROSS_T 	= scross
 
 ARM_COMPILER_EXISTS := $(shell command -v $(CXX_BBB) 2> /dev/null)
 
 
 .PHONY: all
-all : msg mkdir_obj ${LIB_DIR}/gtest-all.o ${LIB_DIR}/gtest-all-arm.o msg_d $(POD_D)-tsan msg_s $(POD_T)-tsan
+all : msg mkdir_obj ${LIB_DIR}/gtest-all.o ${LIB_DIR}/gtest-all-arm.o msg_d $(POD_D_NA)-tsan msg_s $(POD_T)-tsan
 	$(info  =   ___ _   _  ___ ___ ___  ___ ___  )
 	$(info	=  / __| | | |/ __/ __/ _ \/ __/ __| )
 	${info	=  \__ \ |_| | (_| (_|  __/\__ \__ \ }
@@ -152,6 +158,27 @@ $(OBJ_DIR)/%-build.o : %.cpp
 	$(CXX) $? $(CFLAGS) -o $@
 
 #####
+# build-na
+#####
+$(POD_NA)-tsan : LD_NORM := $(LD_NORM) -fsanitize=thread
+$(POD_NA)-tsan : CXX_NORM := $(CXX_NORM) -fsanitize=thread -fPIE -pie
+$(POD_NA)-tsan : $(POD)  #JUMP TO POD to continue compiling
+
+$(POD_NA)-asan : LD_NORM := $(LD_NORM) -fsanitize=address
+$(POD_NA)-asan : CXX_NORM := $(CXX_NORM) -fsanitize=address 
+$(POD_NA)-asan : $(POD)  #JUMP TO POD to continue compiling
+
+$(POD_NA) : CXX 	= $(CXX_NORM)
+$(POD_NA) : CFLAGS 	= $(CFLAGS_RELEASE_NA) $(CFLAGS_NORM)
+$(POD_NA) : LD  	= $(LD_NORM)
+$(POD_NA) : mkdir_obj build-$(POD_NA)
+build-$(POD_NA) : $(OBJ:%.o=$(OBJ_DIR)/%-build.o)
+	$(LD) $? $(LDFLAGS) $(LD_TEST_NORM)  -o $(POD_NA)
+
+$(OBJ_DIR)/%-build.o : %.cpp
+	$(CXX) $? $(CFLAGS) -o $@
+
+#####
 # build-debug
 #####
 $(POD_D)-tsan : LD_NORM := $(LD_NORM) -fsanitize=thread
@@ -168,6 +195,27 @@ $(POD_D) : LD  		= $(LD_NORM)
 $(POD_D) : mkdir_obj build-$(POD_D)
 build-$(POD_D) : $(OBJ:%.o=$(OBJ_DIR)/%-build-debug.o)
 	$(LD) $? $(LDFLAGS) $(LD_TEST_NORM) -o $(POD_D)
+
+$(OBJ_DIR)/%-build-debug.o : %.cpp
+	$(CXX) $? $(CFLAGS) -o $@
+
+#####
+# build-debug-na
+#####
+$(POD_D_NA)-tsan : LD_NORM := $(LD_NORM) -fsanitize=thread
+$(POD_D_NA)-tsan : CXX_NORM := $(CXX_NORM) -fsanitize=thread -fPIE -pie
+$(POD_D_NA)-tsan : $(POD_D)  #JUMP TO POD to continue compiling
+
+$(POD_D_NA)-asan : LD_NORM := $(LD_NORM) -fsanitize=address
+$(POD_D_NA)-asan : CXX_NORM := $(CXX_NORM) -fsanitize=address 
+$(POD_D_NA)-asan : $(POD_D)  #JUMP TO POD to continue compiling
+
+$(POD_D_NA) : CXX		= $(CXX_NORM)
+$(POD_D_NA) : CFLAGS  		= $(CFLAGS_DEBUG_NA) $(CFLAGS_NORM)
+$(POD_D_NA) : LD  		= $(LD_NORM)
+$(POD_D_NA) : mkdir_obj build-$(POD_D_NA)
+build-$(POD_D_NA) : $(OBJ:%.o=$(OBJ_DIR)/%-build-debug.o)
+	$(LD) $? $(LDFLAGS) $(LD_TEST_NORM) -o $(POD_D_NA)
 
 $(OBJ_DIR)/%-build-debug.o : %.cpp
 	$(CXX) $? $(CFLAGS) -o $@
@@ -208,6 +256,19 @@ $(OBJ_DIR)/%-cross.o : %.cpp
 	$(CXX) $? $(CFLAGS) -o $@
 
 #####
+# cross-na
+#####
+$(POD_CROSS_NA) : CXX 		= $(CXX_BBB)
+$(POD_CROSS_NA) : CFLAGS  	= $(CFLAGS_RELEASE_NA) $(CFLAGS_BBB)
+$(POD_CROSS_NA) : LD  		= $(LD_BBB)
+$(POD_CROSS_NA) : mkdir_obj build-$(POD_CROSS_NA)
+build-$(POD_CROSS_NA) : $(OBJ:%.o=$(OBJ_DIR)/%-cross.o)
+	$(LD) $? $(LDFLAGS) $(LD_TEST_ARM) -o $(POD_CROSS_NA)
+
+$(OBJ_DIR)/%-cross.o : %.cpp
+	$(CXX) $? $(CFLAGS) -o $@
+
+#####
 # cross-debug
 #####
 $(POD_CROSS_D) : CXX 	= $(CXX_BBB)
@@ -215,6 +276,19 @@ $(POD_CROSS_D) : CFLAGS = $(CFLAGS_DEBUG) $(CFLAGS_BBB)
 $(POD_CROSS_D) : LD     = $(LD_BBB)
 $(POD_CROSS_D) : mkdir_obj build-$(POD_CROSS_D)
 build-$(POD_CROSS_D) : $(OBJ:%.o=$(OBJ_DIR)/%-cross-debug.o)
+	$(CXX) $? $(LDFLAGS) $(LD_TEST_ARM) -o $(POD_CROSS_D)
+
+$(OBJ_DIR)/%-cross-debug.o : %.cpp
+	$(LD) $? $(CFLAGS) -o $@
+
+#####
+# cross-debug-na
+#####
+$(POD_CROSS_D_NA) : CXX 	= $(CXX_BBB)
+$(POD_CROSS_D_NA) : CFLAGS 	= $(CFLAGS_DEBUG_NA) $(CFLAGS_BBB)
+$(POD_CROSS_D_NA) : LD     	= $(LD_BBB)
+$(POD_CROSS_D_NA) : mkdir_obj build-$(POD_CROSS_D)
+build-$(POD_CROSS_D_NA) : $(OBJ:%.o=$(OBJ_DIR)/%-cross-debug.o)
 	$(CXX) $? $(LDFLAGS) $(LD_TEST_ARM) -o $(POD_CROSS_D)
 
 $(OBJ_DIR)/%-cross-debug.o : %.cpp
@@ -235,7 +309,7 @@ $(OBJ_DIR)/%-cross-sim.o : %.cpp
 
 .PHONY: clean
 clean:
-	rm -f $(POD) $(POD_D) $(POD_T) $(POD_CROSS) $(POD_CROSS_D) $(POD_CROSS_T)
+	rm -f $(POD) $(POD_D) $(POD_T) $(POD_CROSS) $(POD_CROSS_D) $(POD_CROSS_T) $(POD_NA) $(POD_D_NA) $(POD_CROSS_NA) $(POD_CROSS_D_NA)
 	rm -rf $(OBJ_DIR)/  
 
 .PHONY: clean_lib
@@ -249,11 +323,14 @@ ADDR := 128.174.163.125
 push: 
 	$(info  ==============================================)
 	$(info  Ways to push to BBB:)
-	${info  (1) `make push_all`    for all of the following}
-	${info  (2) `make push_sim`    for sim build}
-	${info  (3) `make push_debug`  for debug build}
-	${info  (4) `make push_prod`   for optimized build}
-	${info  (5) `make push_config` for config file}
+	${info  Address is: $(BBB) @ $(ADDR) Modify Makefile to change address }
+	${info  (1) `make push_all`    	  for all of the following}
+	${info  (2) `make push_sim`    	  for sim build}
+	${info  (3) `make push_debug`  	  for debug build}
+	${info  (4) `make push_debug_na`  for debug build (no action) }
+	${info  (5) `make push_prod`      for optimized build}
+	${info  (6) `make push_prod_na`   for optimized build (no action) }
+	${info  (7) `make push_config`    for config file}
 	$(info  ==============================================)
 
 .PHONY: push_all
@@ -267,9 +344,17 @@ push_sim: msg_s mkdir_obj $(POD_CROSS_T)
 push_debug: msg_d mkdir_obj $(POD_CROSS_D) 
 	scp $(POD_CROSS_D) $(BBB)@$(ADDR):~/
 
+.PHONY: push_debug_na
+push_debug_na: msg_d mkdir_obj $(POD_CROSS_D_NA) 
+	scp $(POD_CROSS_D_NA) $(BBB)@$(ADDR):~/
+
 .PHONY: push_prod
 push_prod: msg_p mkdir_obj $(POD_CROSS)
 	scp $(POD_CROSS) $(BBB)@$(ADDR):~/
+
+.PHONY: push_prod_na
+push_prod_na: msg_p mkdir_obj $(POD_CROSS_NA)
+	scp $(POD_CROSS_NA) $(BBB)@$(ADDR):~/
 
 .PHONY: push_config
 push_config: 

--- a/CentralComputing/Motor.cpp
+++ b/CentralComputing/Motor.cpp
@@ -10,21 +10,24 @@ Motor::Motor() {
 void Motor::enable_motors() {
   set_throttle(MOTOR_OFF);
   set_motor_state(true);
-  print(LogLevel::LOG_DEBUG, "Motors Enabled\n");
 }
 
 void Motor::disable_motors() {
   set_throttle(MOTOR_OFF);
   set_motor_state(false);
-  print(LogLevel::LOG_DEBUG, "Motors Disabled\n");
 }
 
 void Motor::set_motor_state(bool enable) {
   enabled = enable;
-  #ifdef SIM
-  SimulatorManager::sim.sim_motor_state(enable);
+  #ifdef NO_ACTION
+    #ifdef SIM
+    SimulatorManager::sim.sim_motor_state(enable);
+    #else
+    print(LogLevel::LOG_DEBUG, "NO_ACTION: Motors: %s\n", enable?"Enabled":"Disabled");
+    #endif
   #else
   SourceManager::CAN.set_motor_state(enable);
+  print(LogLevel::LOG_DEBUG, "Motors: %s\n", enable?"Enabled":"Disabled");
   #endif
 }
 
@@ -39,20 +42,28 @@ int16_t Motor::get_throttle() {
 void Motor::set_throttle(int16_t value) {
   if (enabled) {
     throttle = value;
-    #ifdef SIM
-    SimulatorManager::sim.sim_motor_set_throttle(value);
+    #ifdef NO_ACTION
+      #ifdef SIM
+      SimulatorManager::sim.sim_motor_set_throttle(value);
+      #else
+      print(LogLevel::LOG_DEBUG, "NO_ACTION: Setting motor throttle: %d\n", value);
+      #endif
     #else
     SourceManager::CAN.set_motor_throttle(value);
-    #endif
-    
     print(LogLevel::LOG_DEBUG, "Setting motor throttle: %d\n", value);
+    #endif
   }
 }
 
 void Motor::set_relay_state(HV_Relay_Select relay, HV_Relay_State state) {
-  #ifdef SIM
-  SimulatorManager::sim.sim_relay_state(relay, state);
+  #ifdef NO_ACTION
+    #ifdef SIM
+    SimulatorManager::sim.sim_relay_state(relay, state);
+    #else
+    print(LogLevel::LOG_DEBUG, "NO_ACTION: Relay %d %s\n", relay, state?"Enabled":"Disabled");
+    #endif
   #else
   SourceManager::CAN.set_relay_state(relay, state);
+  print(LogLevel::LOG_DEBUG, "Relay %d %s\n", relay, state?"Enabled":"Disabled");
   #endif
 }

--- a/CentralComputing/Simulator.cpp
+++ b/CentralComputing/Simulator.cpp
@@ -130,11 +130,7 @@ void Simulator::logging(bool enable) {
 
 void Simulator::sim_relay_state(HV_Relay_Select relay, HV_Relay_State state) {
   std::lock_guard<std::mutex> guard(mutex);
-  if (state) {
-    print(LogLevel::LOG_DEBUG, "Sim - Relay %d Enabled\n", relay);
-  } else {
-    print(LogLevel::LOG_DEBUG, "Sim - Relay %d Disabled\n", relay);
-  }
+  print(LogLevel::LOG_DEBUG, "Sim - Relay %d %s\n", relay, state?"Enabled":"Disabled");
   if (scenario != nullptr) {
     scenario->sim_relay_state(relay, state);
   }


### PR DESCRIPTION
Adding a compile-time define statement `NO_ACTION` to enable us to run tests that don't actually control the motor/ brakes/ BMS.

All non-cross-compiled builds have the `NO_ACTION` define. This makes sense, since something running on your laptop shouldn't work anyway. 

For the cross-compiled builds, here are the options:
`cross`
`dcross`
`scross`
as usual. And then we also have:
`cross-na`
`dcross-na`
Which have the `NO_ACTION` define.