### PR TITLE
Added protection against porly formatted commands

### DIFF
--- a/CentralComputing/Command.h
+++ b/CentralComputing/Command.h
@@ -55,6 +55,7 @@ enum Network_Command_ID {
   SET_HV_RELAY_LV_POLE = 27,
   SET_HV_RELAY_PRE_CHARGE = 28,
   CALC_ACCEL_ZERO_G = 29,
+  SENTINEL = 30,
 };
 
 // enum specifying what data is sent

--- a/CentralComputing/Pod.cpp
+++ b/CentralComputing/Pod.cpp
@@ -26,6 +26,13 @@ void Pod::logic_loop() {
 
     if (loaded) {
       print(LogLevel::LOG_INFO, "Command : %d %d\n", com.id, com.value);
+      // Capture any bad commands before they cause a segfault
+      if (com.id >= Command::Network_Command_ID::SENTINEL) {
+        print(LogLevel::LOG_ERROR, "INVALID COMMAND ID: %d\n", com.id);
+        com.id = 0;
+        com.value = 0;
+        break;  // Exit, we can't use this command
+      }
       // Parse the command and call the appropriate state machine function
       auto transition = state_machine->get_transition_function(&com);
       ((*state_machine).*(transition))(); 


### PR DESCRIPTION
Protects against any commands that have an invalid ID. An invalid ID would otherwise cause a segfault...

resolve #158
