### PR TITLE
fix(CentralComputing): add method that was commented out for testing

### DIFF
--- a/CentralComputing/Utils.cpp
+++ b/CentralComputing/Utils.cpp
@@ -70,23 +70,23 @@ int64_t Utils::microseconds() {
   }
 }
 
-// void Utils::busyWait(int64_t microseconds) {
-//   struct timespec currTime;
-//   clockid_t threadClockId;
-//   pthread_getcpuclockid(pthread_self(), &threadClockId);
-//   clock_gettime(threadClockId, &currTime);
-//   time_t secs = (microseconds / 1000000) + currTime.tv_sec + (currTime.tv_nsec / 1000000000);
-//   struct timespec toEnd;
-//   toEnd.tv_sec = secs;
-//   toEnd.tv_nsec = ((microseconds * 1000) + currTime.tv_nsec) % 1000000000;
-//   while (currTime.tv_sec <= toEnd.tv_sec) {
-//     if (currTime.tv_sec == toEnd.tv_sec && currTime.tv_nsec > toEnd.tv_nsec) {
-//       break;
-//     }
-//     clock_gettime(threadClockId, &currTime);
-//   }
-//   return;
-// }
+void Utils::busyWait(int64_t microseconds) {
+  struct timespec currTime;
+  clockid_t threadClockId;
+  pthread_getcpuclockid(pthread_self(), &threadClockId);
+  clock_gettime(threadClockId, &currTime);
+  time_t secs = (microseconds / 1000000) + currTime.tv_sec + (currTime.tv_nsec / 1000000000);
+  struct timespec toEnd;
+  toEnd.tv_sec = secs;
+  toEnd.tv_nsec = ((microseconds * 1000) + currTime.tv_nsec) % 1000000000;
+  while (currTime.tv_sec <= toEnd.tv_sec) {
+    if (currTime.tv_sec == toEnd.tv_sec && currTime.tv_nsec > toEnd.tv_nsec) {
+      break;
+    }
+    clock_gettime(threadClockId, &currTime);
+  }
+  return;
+}
 
 // Returns a number > 0 if success. Otherwise, there was a write failure
 ssize_t Utils::write_all_to_socket(int socket, uint8_t *buffer, size_t count) {


### PR DESCRIPTION
I removed the `void Utils::busyWait(int64_t microseconds)` function because it was giving me some errors when I tried compiling to the `.so` file. This PR uncomments those lines since it works now.